### PR TITLE
Update the session invalidation code

### DIFF
--- a/authentication/api.py
+++ b/authentication/api.py
@@ -55,6 +55,12 @@ def get_user_from_apisix_headers(request):
 
     decoded_headers = decode_apisix_headers(request)
 
+    if request.user.is_authenticated:
+        log.debug(
+            "get_user_from_apisix_headers: existing session found for user %s",
+            request.user.username,
+        )
+
     if not decoded_headers:
         return None
 

--- a/unified_ecommerce/middleware.py
+++ b/unified_ecommerce/middleware.py
@@ -31,23 +31,20 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
                 logout(request)
             return
 
-        if request.user.is_authenticated:
-            # The user is authenticated but like the RemoteUserMiddleware we
-            # should now check and make sure the user APISIX is passing is
-            # the same user.
+        if apisix_user:
+            if request.user.is_authenticated and request.user != apisix_user:
+                # The user is authenticated, but doesn't match the user we got
+                # from APISIX. So, log them out so the APISIX user takes
+                # precedence.
 
-            if request.user != apisix_user:
                 logout(request)
 
-            return
-
-        if not apisix_user:
-            logout(request)
-
-            return
-
-        request.user = apisix_user
-        login(request, apisix_user, backend="django.contrib.auth.backends.ModelBackend")
+            request.user = apisix_user
+            login(
+                request,
+                apisix_user,
+                backend="django.contrib.auth.backends.ModelBackend",
+            )
 
         return
 

--- a/unified_ecommerce/middleware.py
+++ b/unified_ecommerce/middleware.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from django.contrib.auth import login
+from django.contrib.auth import login, logout
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.core.exceptions import ImproperlyConfigured
 
@@ -28,7 +28,7 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
             apisix_user = get_user_from_apisix_headers(request)
         except KeyError:
             if self.force_logout_if_no_header and request.user.is_authenticated:
-                self._remove_invalid_user(request)
+                logout(request)
             return
 
         if request.user.is_authenticated:
@@ -37,12 +37,12 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
             # the same user.
 
             if request.user != apisix_user:
-                self._remove_invalid_user(request)
+                logout(request)
 
             return
 
         if not apisix_user:
-            self._remove_invalid_user(request)
+            logout(request)
 
             return
 


### PR DESCRIPTION

### What are the relevant tickets?

n/a

### Description (What does it do?)

This was using `_remove_invalid_user` from the upstream `RemoteUserBackend` middleware - but that only works if the middleware is specifically `RemoteUserBackend`, so now instead log them out using auth.logout.

### How can this be tested?

Set one of your APISIX created users up with an actual password and set them to Staff status so they can log into the Django Admin directly (at http://ue.odl.local:8073 if you're using the default hostname).

On the main branch:
1. Log into Django Admin with the aforementioned user. 
2. Then, go to the cart page directly (e.g. without APISIX) - http://ue.odl.local:8073
3. Optionally add an item to the cart - just for visibility. 
4. Navigate to the system via APISIX - http://ue.odl.local:9080 - and log in with a _different_ account. 
5. You should still be logged in with the first user.

Repeat these steps on this branch. When you hit step 5, you should be logged in as the different account. Additionally, you should be still able to log into the Django Admin using your Django superuser account.