### PR TITLE
Fixes a few things in the events system

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This application provides a central system to handle ecommerce activities across
   - [Committing \& Formatting](#committing--formatting)
   - [Optional Setup](#optional-setup)
     - [Interstitial Debug Mode](#interstitial-debug-mode)
+    - [Webhook Retry](#webhook-retry)
     - [Running the app in a notebook](#running-the-app-in-a-notebook)
 
 ## Initial Setup
@@ -188,6 +189,15 @@ Described below are some setup steps that are not strictly necessary for running
 ### Interstitial Debug Mode
 
 You can set `MITOL_UE_PAYMENT_INTERSTITIAL_DEBUG` to control whether or not the checkout interstitial page displays additional data and waits to submit or not. By default, this tracks the `DEBUG` setting (so it should be off in production, and on in local testing).
+
+### Webhook Retry
+
+The events system will attempt to ping integrated systems via a webhook when orders hit certain states (such as completed or refunded). You can control how this works with these settings:
+
+- `MITOL_UE_WEBHOOK_RETRY_MAX` - Max number of attempts to make to hit a webhook. Defaults to 4.
+- `MITOL_UE_WEBHOOK_RETRY_COOLDOWN` - How long to wait between retrying, in seconds. Defaults to 60 seconds.
+
+The retry happens if the request times out, returns an HTTP error, or returns a connection error. If the webhook isn't configured with a URL, if it returns non-JSON data or a redirect loop, or some other error happens, the system _will not_ retry the webhook and an error message will be emitted to that effect. Similarly, if it falls out the end of the available retries it will also emit an error message and stop.
 
 ### Running the app in a notebook
 

--- a/cart/views.py
+++ b/cart/views.py
@@ -26,11 +26,9 @@ from unified_ecommerce.constants import (
     USER_MSG_TYPE_PAYMENT_ERROR,
     USER_MSG_TYPE_PAYMENT_ERROR_UNKNOWN,
 )
-from unified_ecommerce.plugin_manager import get_plugin_manager
 from unified_ecommerce.utils import redirect_with_user_message
 
 log = logging.getLogger(__name__)
-pm = get_plugin_manager()
 
 
 class CartView(LoginRequiredMixin, TemplateView):
@@ -150,9 +148,10 @@ class CheckoutCallbackView(View):
 
             if order.state == Order.STATE.PENDING:
                 processed_order_state = api.process_cybersource_payment_response(
-                    request, order
+                    request,
+                    order,
+                    POST_SALE_SOURCE_REDIRECT,
                 )
-                pm.hook.post_sale(order_id=order.id, source=POST_SALE_SOURCE_REDIRECT)
 
                 return self.post_checkout_redirect(processed_order_state, request)
             else:

--- a/payments/hooks/post_sale.py
+++ b/payments/hooks/post_sale.py
@@ -3,11 +3,6 @@
 import logging
 
 import pluggy
-import requests
-
-from payments.constants import PAYMENT_HOOK_ACTION_POST_SALE
-from payments.models import Order
-from payments.serializers.v0 import WebhookBase, WebhookBaseSerializer, WebhookOrder
 
 hookimpl = pluggy.HookimplMarker("unified_ecommerce")
 
@@ -27,64 +22,9 @@ class PostSaleSendEmails:
 class IntegratedSystemWebhooks:
     """Figures out what webhook endpoints to call, and calls them."""
 
-    def post_sale_impl(self, order_id, source):
-        """Call the webhook endpoints for the order."""
-
-        log = logging.getLogger(__name__)
-
-        log.info(
-            "Calling webhook endpoints for order %s with source %s", order_id, source
-        )
-
-        order = Order.objects.prefetch_related("lines", "lines__product_version").get(
-            pk=order_id
-        )
-
-        systems = [
-            product.system
-            for product in [
-                line.product_version._object_version.object  # noqa: SLF001
-                for line in order.lines.all()
-            ]
-        ]
-
-        for system in systems:
-            system_webhook_url = system.webhook_url
-            system_slug = system.slug
-            if system_webhook_url:
-                log.info(
-                    ("Calling webhook endpoint %s for order %s with source %s"),
-                    system_webhook_url,
-                    order_id,
-                    source,
-                )
-
-                order_info = WebhookOrder(
-                    order=order,
-                    lines=[
-                        line
-                        for line in order.lines.all()
-                        if line.product.system.slug == system_slug
-                    ],
-                )
-
-                webhook_data = WebhookBase(
-                    type=PAYMENT_HOOK_ACTION_POST_SALE,
-                    system_key=system.api_key,
-                    user=order.purchaser,
-                    data=order_info,
-                )
-
-                serializer = WebhookBaseSerializer(webhook_data)
-
-                requests.post(
-                    system_webhook_url,
-                    json=serializer.data,
-                    timeout=30,
-                )
-
     @hookimpl
     def post_sale(self, order_id, source):
         """Call the implementation of this, so we can test it more easily."""
+        from payments.api import process_post_sale_webhooks
 
-        self.post_sale_impl(order_id, source)
+        process_post_sale_webhooks(order_id, source)

--- a/payments/models.py
+++ b/payments/models.py
@@ -40,21 +40,10 @@ class Basket(TimestampedModel):
         if self.user != order.purchaser:
             return False
 
-        if self.basket_items.count() != order.lines.count():
-            return False
+        basket_products = {item.product for item in self.basket_items.all()}
+        order_products = {line.product for line in order.lines.all()}
 
-        for basket_item in self.basket_items.all():
-            found_this_one = False
-
-            for order_item in order.lines.all():
-                if order_item.product == basket_item.product:
-                    found_this_one = True
-                    break
-
-            if not found_this_one:
-                return False
-
-        return True
+        return basket_products == order_products
 
     def get_products(self):
         """

--- a/payments/serializers/v0/__init__.py
+++ b/payments/serializers/v0/__init__.py
@@ -27,7 +27,7 @@ class WebhookOrder:
     """
 
     order: Order
-    lines: Line
+    lines: list[Line]
 
 
 @dataclass

--- a/payments/tasks.py
+++ b/payments/tasks.py
@@ -1,0 +1,120 @@
+"""Tasks for the payments app."""
+
+import logging
+
+import requests
+from django.conf import settings
+
+from payments.constants import PAYMENT_HOOK_ACTION_POST_SALE
+from payments.serializers.v0 import WebhookBase, WebhookBaseSerializer, WebhookOrder
+from unified_ecommerce.celery import app
+
+log = logging.getLogger(__name__)
+
+
+@app.task()
+def send_post_sale_webhook(system, order, source, attempt_count=0):
+    """
+    Actually send the webhook some data for a post-sale event.
+
+    This is split out so we can queue the webhook requests individually.
+    """
+
+    system_webhook_url = system.webhook_url
+    if system_webhook_url:
+        log.info(
+            ("Calling webhook endpoint %s for order %s with source %s"),
+            system_webhook_url,
+            order.reference_number,
+            source,
+        )
+
+    order_info = WebhookOrder(
+        order=order,
+        lines=[
+            line
+            for line in order.lines.all()
+            if line.product.system.slug == system.slug
+        ],
+    )
+
+    webhook_data = WebhookBase(
+        type=PAYMENT_HOOK_ACTION_POST_SALE,
+        system_key=system.api_key,
+        user=order.purchaser,
+        data=order_info,
+    )
+
+    serializer = WebhookBaseSerializer(webhook_data)
+
+    try:
+        requests.post(
+            system_webhook_url,
+            json=serializer.data,
+            timeout=30,
+        )
+    except (requests.Timeout, requests.HTTPError, requests.ConnectionError) as e:
+        # These may indicate an issue on the integrated system end, so we'll
+        # delay it for a while and retry, as long as it isn't too many times.
+
+        log.warning(
+            (
+                "Had problems getting to the webhook URL %s on attempt %s for "
+                "order %s for system %s: %s"
+            ),
+            system_webhook_url,
+            attempt_count,
+            order.reference_number,
+            system.slug,
+            e,
+        )
+
+        attempt_count += 1
+
+        if attempt_count == settings.MITOL_UE_WEBHOOK_RETRY_MAX:
+            log.exception(
+                (
+                    "Hit the retry max (%s) for webhook URL %s for order %s for "
+                    "system %s, giving up"
+                ),
+                attempt_count,
+                order.reference_number,
+                system.slug,
+                exc_info=e,
+            )
+            return
+
+        send_post_sale_webhook.s(system, order, source, attempt_count).apply_async(
+            countdown=settings.MITOL_UE_WEBHOOK_RETRY_COOLDOWN
+        )
+    except (
+        requests.URLRequired,
+        requests.TooManyRedirects,
+        requests.JSONDecodeError,
+    ) as e:
+        # These may indicate that the webhook URL is wrong - it's either not set
+        # or set to something that is returning gibberish, so don't retry.
+
+        log.exception(
+            (
+                "Webhook URL %s for system %s in order %s returned something "
+                "unexpected: %s"
+            ),
+            system_webhook_url,
+            system.slug,
+            order.reference_number,
+            exc_info=e,
+        )
+    except requests.RequestException as e:
+        # Some other error happened.
+
+        log.exception(
+            (
+                "Unexpected error trying to dispatch to webhook URL %s for "
+                "system %s in order %s returned something unexpected: %s"
+            ),
+            system_webhook_url,
+            system.slug,
+            order.reference_number,
+            exc_info=e,
+        )

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -24,6 +24,7 @@ from payments import api
 from payments.models import Basket, BasketItem, Order
 from payments.serializers.v0 import BasketItemSerializer, BasketSerializer
 from system_meta.models import IntegratedSystem, Product
+from unified_ecommerce.constants import POST_SALE_SOURCE_BACKOFFICE
 
 log = logging.getLogger(__name__)
 
@@ -226,6 +227,8 @@ class BackofficeCallbackView(APIView):
             if order is None:
                 raise Http404
             elif order.state == Order.STATE.PENDING:
-                api.process_cybersource_payment_response(request, order)
+                api.process_cybersource_payment_response(
+                    request, order, POST_SALE_SOURCE_BACKOFFICE
+                )
 
             return Response(status=status.HTTP_200_OK)

--- a/unified_ecommerce/settings.py
+++ b/unified_ecommerce/settings.py
@@ -449,6 +449,9 @@ MITOL_UE_REFERENCE_NUMBER_PREFIX = get_string(
 MITOL_UE_PAYMENT_INTERSTITIAL_DEBUG = get_bool(
     "MITOL_UE_PAYMENT_INTERSTITIAL_DEBUG", DEBUG
 )
+MITOL_UE_WEBHOOK_RETRY_COOLDOWN = get_int("MITOL_UE_WEBHOOK_RETRY_COOLDOWN", 60)
+MITOL_UE_WEBHOOK_RETRY_MAX = get_int("MITOL_UE_WEBHOOK_RETRY_MAX", 4)
+
 import_settings_modules("mitol.payment_gateway.settings.cybersource")
 
 # Keycloak API settings


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/5663

### Description (What does it do?)

[The initial PR for the events system](https://github.com/mitodl/unified-ecommerce/pull/135) worked but there were a few things that would have been nice to refine a bit more. This PR does that:
- Pulls the webhook dispatcher logic out of the event plugin itself and into an API function and a task
   - Moving this to a task allows us to fire the event but not have to wait on it to complete, like it was
   - This also allows the webhook tasks to be retried if the integrated system is unresponsive for whatever reason
- Fixes a couple of minor things in the code
- Updates the `fulfill` functionality in the model so that the events fire correctly. The `fulfill` method now explicitly fires the event - it was being attached to the (database) transaction, and thus wasn't firing at all prior to this.
- Updates the API calls to simply fulfill the transaction and not manually fire the events.
- Updates the webhook dispatcher for post-sale events to skip systems that don't have a webhook URL set.
- Added a few more tests to make sure things are being dispatched as they should.

### How can this be tested?

Automated tests should pass.

Checking out with a system that has a configured webhook URL should continue to work as expected.

If the webhook location is unavailable, the webhook dispatcher should re-queue itself and try again a set number of times with a cooldown period in between. These settings are configurable, and the retry should only happen if the system gets a HTTP error, a connection error, or times out trying to connect to the URL. 

### Additional Context

There are two new settings that can be set to configure the retry limit and the cooldown period. These are documented in the `README.md`. The defaults are (IMHO) sensible but you may want to set the timeout down a lot for testing.