### PR TITLE
Adding some minor stuff for sharing Keycloak with Learn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ tsconfig.tsbuildinfo
 # Non-default Keycloak certificates
 config/keycloak/tls/tls.crt
 config/keycloak/tls/tls.key
+
+# Docker Compose override
+docker-compose.override.yml

--- a/README-keycloak-learn.md
+++ b/README-keycloak-learn.md
@@ -1,0 +1,59 @@
+# Using Unified Ecommerce's Keycloak with Learn
+
+You can use the UE pack-in Keycloak instance with Learn, so they share a common SSO system. It's only a few steps to do this.
+
+## Docker Compose setup
+
+The UE Keycloak instance needs to know about the Learn network. So, create a `docker-compose.override.yml` in UE:
+
+```
+services:
+  keycloak:
+    networks:
+      default:
+        priority: 1000
+
+      mit-open_default:
+        aliases:
+        - ${KEYCLOAK_SVC_HOSTNAME:-kc.odl.local}
+
+networks:
+  mit-open_default:
+    external: true
+```
+
+Replace `mit-open_default` with the network name for your Learn instance. Do `docker network ls` to find this - it's usually the project name plus `_default`.
+
+This does a couple things:
+- Sets the default network to have higher priority than the Learn one.
+- Adds an alias for the Keycloak instance to the Learn network.
+
+And there's one consideration: because this links UE to your Learn instance's network, if you `docker compose down` and it brings the Learn network down, your UE instance will not start. Make sure you have Learn running before you start UE.
+
+## App Setup
+
+_Optional:_ If you want, you can set up a separate client for Learn. You don't have to do this - it can use the `apisix` client that is already set up.
+
+Set your Learn instance's `.env` file appropriately for the UE Keycloak instance:
+
+```
+OIDC_ENDPOINT=http://kc.odl.local:7080/realms/ol-local
+SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.odl.local:7080/realms/ol-local
+SOCIAL_AUTH_OL_OIDC_KEY=apisix
+SOCIAL_AUTH_OL_OIDC_SECRET=<the secret you use>
+AUTHORIZATION_URL=http://kc.odl.local:7080/realms/ol-local/protocol/openid-connect/auth
+ACCESS_TOKEN_URL=http://kc.odl.local:7080/realms/ol-local/protocol/openid-connect/token
+USERINFO_URL=http://kc.odl.local:7080/realms/ol-local/protocol/openid-connect/userinfo
+KEYCLOAK_BASE_URL=http://kc.odl.local:7080
+KEYCLOAK_REALM_NAME=ol-local
+```
+
+These URLs should _generally_ work but you may need to verify them (sometimes Keycloak moves them between versions). Note that these all use the _bare HTTP_ endpoints for Keycloak. Unless you've put a real certificate on your Keycloak instance, the Learn app will not be able to communicate with it over HTTPS.
+
+Next, set your UE instance's `.env` file appropriately. UE should use the same hostname and scheme to connect to Keycloak that Learn uses so they can share sessions. So, if you were using HTTPS for Keycloak in UE, change that to HTTP.
+
+## Bring Everything Up
+
+Stop everything if you haven't already. Then, bring up Learn first, followed by UE. (Don't forget the Keycloak profile.)
+
+You should be able to now log into Learn using the Keycloak instance, and navigating into UE should use that same session. If you log out of Learn, or log out and back in as a different user, that state should follow into UE too.

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -26,9 +26,10 @@ routes:
         client_secret: ${{KEYCLOAK_CLIENT_SECRET}}
         discovery: ${{KEYCLOAK_DISCOVERY_URL}}
         realm: ${{KEYCLOAK_REALM}}
-        scope: "openid profile"
+        scope: "openid profile ol-profile"
         bearer_only: false
         introspection_endpoint_auth_method: "client_secret_post"
+        ssl_verify: false
     uris:
     - "/*"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,25 +57,6 @@ services:
       - .:/src
       - django_media:/var/media
 
-  # watch:
-  #   build:
-  #     context: .
-  #     dockerfile: Dockerfile-node
-  #   working_dir: /src
-  #   command: ./scripts/run-watch-dev.sh
-  #   ports:
-  #     - "8052:8052"
-  #     - "8062:8062"
-  #   environment:
-  #     DOCKER_HOST: ${DOCKER_HOST:-missing}
-  #     NODE_ENV: ${NODE_ENV:-development}
-  #     CONTAINER_NAME: "watch"
-  #     WEBPACK_PORT_MITOPEN: 8062
-  #   env_file: .env
-  #   volumes:
-  #     - .:/src
-  #     - yarn-cache:/home/mitodl/.cache/yarn
-
   celery:
     build:
       context: .
@@ -127,7 +108,9 @@ services:
       default:
         aliases:
         - ${KEYCLOAK_SVC_HOSTNAME:-kc.odl.local}
-    command: start --verbose --features scripts --import-realm --hostname=${KEYCLOAK_SVC_HOSTNAME:-kc.odl.local} --hostname-strict=false --hostname-debug=true --https-port=7443 --https-certificate-file=/etc/x509/https/tls.crt --https-certificate-key-file=/etc/x509/https/tls.key --http-enabled=true --http-port=7080 --config-keystore=/etc/keycloak-store --config-keystore-password=${KEYCLOAK_SVC_KEYSTORE_PASSWORD} --db=postgres --db-url-database=keycloak --db-url-host=db --db-schema=public --db-password=${POSTGRES_PASSWORD} --db-username=postgres
+    links:
+      - db:uedb
+    command: start --verbose --features scripts --import-realm --hostname=${KEYCLOAK_SVC_HOSTNAME:-kc.odl.local} --hostname-strict=false --hostname-debug=true --https-port=7443 --https-certificate-file=/etc/x509/https/tls.crt --https-certificate-key-file=/etc/x509/https/tls.key --http-enabled=true --http-port=7080 --config-keystore=/etc/keycloak-store --config-keystore-password=${KEYCLOAK_SVC_KEYSTORE_PASSWORD} --db=postgres --db-url-database=keycloak --db-url-host=uedb --db-schema=public --db-password=${POSTGRES_PASSWORD} --db-username=postgres
     volumes:
       - keycloak-store:/etc/keycloak-store
       - ./config/keycloak/tls:/etc/x509/https


### PR DESCRIPTION

### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5656

### Description (What does it do?)

It's pretty important that Learn and UE share a SSO source - otherwise the cart functionality that's in process won't work. So, this makes a couple of minor configuration changes and adds some documentation to get that working. 

This is only required if you want to use the pack-in Keycloak that comes with UE with Learn. If you've got a separate Keycloak instance, or you're using the RC one, you won't need to do this step. 

### How can this be tested?

You'll need a Learn instance set up. It doesn't need content but it will need to be there.  

Follow the instructions in `README-keycloak-learn.md` and make sure it works as described there. This necessarily means you'll need to follow the instructions in `README-keycloak.md` too, since you'll need to have the pack-in Keycloak instance working. 
