### PR TITLE
Updates to auth and basket APIs for frontend code

### DIFF
--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -34,10 +34,10 @@ routes:
         introspection_endpoint_auth_method: "client_secret_post"
         ssl_verify: false
         logout_path: "/logout/"
-        post_logout_redirect_uri: "http://ue.odl.local:9080/auth/logout/"
+        post_logout_redirect_uri: ${{UE_LOGOUT_URL}}
       cors:
-        allow_origins: "http://learn.odl.local:8062,http://ue.odl.local:9080"
-        allow_methods: "GET,POST,PUT,DELETE,OPTIONS"
+        allow_origins: "**"
+        allow_methods: "**"
         allow_headers: "**"
         allow_credential: true
       response-rewrite:

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -3,10 +3,6 @@ upstreams:
     nodes:
       "nginx:8073": 1
     type: roundrobin
-  - id: 2
-    nodes:
-      "keycloak:9080": 1
-    type: roundrobin
 
 routes:
   - id: 1

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -6,8 +6,21 @@ upstreams:
 
 routes:
   - id: 1
+    name: "ue-unauth"
+    desc: "Unauthenticated routes, including assets and checkout callback API"
+    priority: 0
+    upstream_id: 1
+    plugins: {}
+    uris:
+    - "/api/v0/payments/checkout/result/*"
+    - "/static/*"
+    - "/api/v0/schema/*"
+    - "/auth/*"
+    - "/_/v0/meta/apisix_test_request/"
+    - "/logged_out/"
+  - id: 2
     name: "ue-default"
-    desc: "System routes that require OIDC authentication."
+    desc: "Wildcard route for the rest of the system - authentication required"
     priority: 1
     upstream_id: 1
     plugins:
@@ -23,7 +36,7 @@ routes:
         logout_path: "/logout/"
         post_logout_redirect_uri: "http://ue.odl.local:9080/auth/logout/"
       cors:
-        allow_origins: "**"
+        allow_origins: "http://learn.odl.local:8062,http://ue.odl.local:9080"
         allow_methods: "GET,POST,PUT,DELETE,OPTIONS"
         allow_headers: "**"
         allow_credential: true
@@ -31,24 +44,7 @@ routes:
         headers:
           set:
             Referrer-Policy: "origin"
-    host: "ue.odl.local"
     uris:
-    - "/establish_session/*"
-    - "/cart/*"
-    - "/admin/*"
-  - id: 2
-    name: "ue-unauth"
-    desc: "Everything else."
-    priority: 0
-    upstream_id: 1
-    plugins:
-      cors:
-        allow_origins: "**"
-        allow_methods: "GET,POST,PUT,DELETE,OPTIONS"
-        allow_headers: "**"
-        allow_credential: true
-    host: "ue.odl.local"
-    uris:
-    - "*"
+    - "/*"
 
 #END

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -15,6 +15,9 @@ routes:
     - "/api/v0/payments/checkout/result/*"
     - "/static/*"
     - "/api/v0/schema/*"
+    - "/auth/*"
+    - "/_/v0/meta/apisix_test_request/"
+    - "/logged_out/"
   - id: 2
     name: "ue-default"
     desc: "Wildcard route for the rest of the system - authentication required"
@@ -30,6 +33,17 @@ routes:
         bearer_only: false
         introspection_endpoint_auth_method: "client_secret_post"
         ssl_verify: false
+        logout_path: "/logout/"
+        post_logout_redirect_uri: "http://ue.odl.local:9080/auth/logout/"
+      cors:
+        allow_origins: "http://learn.odl.local:8062,http://ue.odl.local:9080"
+        allow_methods: "GET,POST,PUT,DELETE,OPTIONS"
+        allow_headers: "**"
+        allow_credential: true
+      response-rewrite:
+        headers:
+          set:
+            Referrer-Policy: "origin"
     uris:
     - "/*"
 

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -3,24 +3,15 @@ upstreams:
     nodes:
       "nginx:8073": 1
     type: roundrobin
+  - id: 2
+    nodes:
+      "keycloak:9080": 1
+    type: roundrobin
 
 routes:
   - id: 1
-    name: "ue-unauth"
-    desc: "Unauthenticated routes, including assets and checkout callback API"
-    priority: 0
-    upstream_id: 1
-    plugins: {}
-    uris:
-    - "/api/v0/payments/checkout/result/*"
-    - "/static/*"
-    - "/api/v0/schema/*"
-    - "/auth/*"
-    - "/_/v0/meta/apisix_test_request/"
-    - "/logged_out/"
-  - id: 2
     name: "ue-default"
-    desc: "Wildcard route for the rest of the system - authentication required"
+    desc: "System routes that require OIDC authentication."
     priority: 1
     upstream_id: 1
     plugins:
@@ -36,7 +27,7 @@ routes:
         logout_path: "/logout/"
         post_logout_redirect_uri: "http://ue.odl.local:9080/auth/logout/"
       cors:
-        allow_origins: "http://learn.odl.local:8062,http://ue.odl.local:9080"
+        allow_origins: "**"
         allow_methods: "GET,POST,PUT,DELETE,OPTIONS"
         allow_headers: "**"
         allow_credential: true
@@ -44,7 +35,24 @@ routes:
         headers:
           set:
             Referrer-Policy: "origin"
+    host: "ue.odl.local"
     uris:
-    - "/*"
+    - "/establish_session/*"
+    - "/cart/*"
+    - "/admin/*"
+  - id: 2
+    name: "ue-unauth"
+    desc: "Everything else."
+    priority: 0
+    upstream_id: 1
+    plugins:
+      cors:
+        allow_origins: "**"
+        allow_methods: "GET,POST,PUT,DELETE,OPTIONS"
+        allow_headers: "**"
+        allow_credential: true
+    host: "ue.odl.local"
+    uris:
+    - "*"
 
 #END

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
     - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET}
     - KEYCLOAK_DISCOVERY_URL=${KEYCLOAK_DISCOVERY_URL:-https://kc.odl.local:7443/realms/ol-local/.well-known/openid-configuration}
     - APISIX_PORT=${APISIX_PORT:-9080}
+    - UE_LOGOUT_URL=${UE_LOGOUT_URL:-http://ue.odl.local:9080/auth/logout/}
     ports:
       - 9080:9080
       - 9180:9180

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -687,6 +687,43 @@ export type StateEnum = typeof StateEnum[keyof typeof StateEnum];
 
 
 /**
+ * Serializer for User model.
+ * @export
+ * @interface User
+ */
+export interface User {
+    /**
+     *
+     * @type {number}
+     * @memberof User
+     */
+    'id': number;
+    /**
+     * Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.
+     * @type {string}
+     * @memberof User
+     */
+    'username': string;
+    /**
+     *
+     * @type {string}
+     * @memberof User
+     */
+    'email'?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof User
+     */
+    'first_name'?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof User
+     */
+    'last_name'?: string;
+}
+/**
  * * `profile` - profile * `geoip` - geoip * `none` - none
  * @export
  * @enum {string}
@@ -2441,5 +2478,102 @@ export class PaymentsApi extends BaseAPI {
      */
     public paymentsOrdersHistoryRetrieve(requestParameters: PaymentsApiPaymentsOrdersHistoryRetrieveRequest, options?: RawAxiosRequestConfig) {
         return PaymentsApiFp(this.configuration).paymentsOrdersHistoryRetrieve(requestParameters.id, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * UsersApi - axios parameter creator
+ * @export
+ */
+export const UsersApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * User retrieve and update viewsets for the current user
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        usersMeRetrieve: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v0/users/me/`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * UsersApi - functional programming interface
+ * @export
+ */
+export const UsersApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = UsersApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * User retrieve and update viewsets for the current user
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async usersMeRetrieve(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<User>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.usersMeRetrieve(options);
+            const index = configuration?.serverIndex ?? 0;
+            const operationBasePath = operationServerMap['UsersApi.usersMeRetrieve']?.[index]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * UsersApi - factory interface
+ * @export
+ */
+export const UsersApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = UsersApiFp(configuration)
+    return {
+        /**
+         * User retrieve and update viewsets for the current user
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        usersMeRetrieve(options?: RawAxiosRequestConfig): AxiosPromise<User> {
+            return localVarFp.usersMeRetrieve(options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * UsersApi - object-oriented interface
+ * @export
+ * @class UsersApi
+ * @extends {BaseAPI}
+ */
+export class UsersApi extends BaseAPI {
+    /**
+     * User retrieve and update viewsets for the current user
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UsersApi
+     */
+    public usersMeRetrieve(options?: RawAxiosRequestConfig) {
+        return UsersApiFp(this.configuration).usersMeRetrieve(options).then((request) => request(this.axios, this.basePath));
     }
 }

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -454,6 +454,19 @@ paths:
               schema:
                 $ref: '#/components/schemas/OrderHistory'
           description: ''
+  /api/v0/users/me/:
+    get:
+      operationId: users_me_retrieve
+      description: User retrieve and update viewsets for the current user
+      tags:
+      - users
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: ''
 components:
   schemas:
     BasketItemWithProduct:
@@ -928,6 +941,33 @@ components:
       - Declined
       - Errored
       - Review
+    User:
+      type: object
+      description: Serializer for User model.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        username:
+          type: string
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+            only.
+          pattern: ^[\w.@+-]+$
+          maxLength: 150
+        email:
+          type: string
+          format: email
+          title: Email address
+          maxLength: 254
+        first_name:
+          type: string
+          maxLength: 150
+        last_name:
+          type: string
+          maxLength: 150
+      required:
+      - id
+      - username
     UserTaxableGeolocationTypeEnum:
       enum:
       - profile

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -9,6 +9,7 @@ from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from django_filters import rest_framework as filters
 from drf_spectacular.utils import (
     OpenApiParameter,
     OpenApiResponse,
@@ -54,6 +55,16 @@ pm = get_plugin_manager()
 # Baskets
 
 
+class BasketFilter(filters.FilterSet):
+    """Filter class for Basket, just so we can filter by integrated system."""
+
+    class Meta:
+        """Meta class for BasketFilter"""
+
+        model = Basket
+        fields = ["integrated_system"]
+
+
 @extend_schema_view(
     list=extend_schema(
         description=("Retrives the current user's baskets, one per system.")
@@ -69,7 +80,9 @@ class BasketViewSet(ReadOnlyModelViewSet):
     """API view set for Basket"""
 
     serializer_class = BasketWithProductSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = (IsAuthenticated,)
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = BasketFilter
 
     def get_queryset(self):
         """Return only baskets owned by this user."""

--- a/unified_ecommerce/middleware.py
+++ b/unified_ecommerce/middleware.py
@@ -3,7 +3,7 @@
 import logging
 
 from django.contrib.auth import login, logout
-from django.contrib.auth.middleware import RemoteUserMiddleware
+from django.contrib.auth.middleware import PersistentRemoteUserMiddleware
 from django.core.exceptions import ImproperlyConfigured
 
 from unified_ecommerce.utils import decode_apisix_headers, get_user_from_apisix_headers
@@ -11,7 +11,7 @@ from unified_ecommerce.utils import decode_apisix_headers, get_user_from_apisix_
 log = logging.getLogger(__name__)
 
 
-class ApisixUserMiddleware(RemoteUserMiddleware):
+class ApisixUserMiddleware(PersistentRemoteUserMiddleware):
     """Checks for and processes APISIX-specific headers."""
 
     def process_request(self, request):
@@ -28,6 +28,7 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
             apisix_user = get_user_from_apisix_headers(request)
         except KeyError:
             if self.force_logout_if_no_header and request.user.is_authenticated:
+                log.debug("Forcing user logout due to missing APISIX headers.")
                 logout(request)
             return None
 

--- a/unified_ecommerce/middleware.py
+++ b/unified_ecommerce/middleware.py
@@ -37,6 +37,9 @@ class ApisixUserMiddleware(PersistentRemoteUserMiddleware):
                 # The user is authenticated, but doesn't match the user we got
                 # from APISIX. So, log them out so the APISIX user takes
                 # precedence.
+                log.debug(
+                    "Forcing user logout because request user doesn't match APISIX user"
+                )
 
                 logout(request)
 

--- a/unified_ecommerce/settings.py
+++ b/unified_ecommerce/settings.py
@@ -133,7 +133,7 @@ LOGIN_REDIRECT_URL = "/"
 LOGIN_URL = "/login"
 LOGIN_ERROR_URL = "/login"
 LOGOUT_URL = "/logout"
-LOGOUT_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "/logged_out"
 
 ROOT_URLCONF = "unified_ecommerce.urls"
 

--- a/unified_ecommerce/urls.py
+++ b/unified_ecommerce/urls.py
@@ -23,7 +23,7 @@ from django.urls import include, path, re_path
 
 urlpatterns = [
     path("", include("cart.urls")),
-    path("", include("django.contrib.auth.urls")),
+    path("auth/", include("django.contrib.auth.urls")),
     path("admin/", admin.site.urls),
     path("hijack/", include("hijack.urls")),
     # OAuth2 Paths
@@ -33,6 +33,7 @@ urlpatterns = [
     # Private Paths
     re_path(r"^_/v0/meta/", include("system_meta.private_urls")),
     # API Paths
+    re_path(r"", include("users.urls")),
     re_path(r"", include("payments.urls")),
     re_path(r"", include("system_meta.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/users/templates/logged_out.html
+++ b/users/templates/logged_out.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Logged out</title>
+    </head>
+
+    <body>
+        <h1>You're logged out.</h1>
+    </body>
+</html>

--- a/users/urls.py
+++ b/users/urls.py
@@ -2,7 +2,12 @@
 
 from django.urls import include, re_path
 
-from users.views import CurrentUserRetrieveViewSet, LoggedOutView
+from users.views import (
+    CurrentUserRetrieveViewSet,
+    LoggedOutView,
+    establish_session,
+    session_check,
+)
 
 v0_urls = [
     re_path(
@@ -16,6 +21,16 @@ urlpatterns = [
         r"^logged_out/$",
         LoggedOutView.as_view(),
         name="logged_out_page",
+    ),
+    re_path(
+        r"^session_check/$",
+        session_check,
+        name="users-session_check",
+    ),
+    re_path(
+        r"^establish_session/$",
+        establish_session,
+        name="users-establish_session",
     ),
     re_path(r"^api/v0/users/", include((v0_urls, "v0"))),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,21 @@
+"""Routes for the users app."""
+
+from django.urls import include, re_path
+
+from users.views import CurrentUserRetrieveViewSet, LoggedOutView
+
+v0_urls = [
+    re_path(
+        r"^me/$",
+        CurrentUserRetrieveViewSet.as_view({"get": "retrieve"}),
+    ),
+]
+
+urlpatterns = [
+    re_path(
+        r"^logged_out/$",
+        LoggedOutView.as_view(),
+        name="logged_out_page",
+    ),
+    re_path(r"^api/v0/users/", include((v0_urls, "v0"))),
+]

--- a/users/urls.py
+++ b/users/urls.py
@@ -6,7 +6,6 @@ from users.views import (
     CurrentUserRetrieveViewSet,
     LoggedOutView,
     establish_session,
-    session_check,
 )
 
 v0_urls = [
@@ -21,11 +20,6 @@ urlpatterns = [
         r"^logged_out/$",
         LoggedOutView.as_view(),
         name="logged_out_page",
-    ),
-    re_path(
-        r"^session_check/$",
-        session_check,
-        name="users-session_check",
     ),
     re_path(
         r"^establish_session/$",

--- a/users/views.py
+++ b/users/views.py
@@ -1,0 +1,25 @@
+"""Views for the users app."""
+
+from django.views.generic import TemplateView
+from rest_framework import mixins, viewsets
+from rest_framework.permissions import IsAuthenticated
+
+from unified_ecommerce.serializers import UserSerializer
+
+
+class LoggedOutView(TemplateView):
+    """View for the logged out page."""
+
+    template_name = "logged_out.html"
+
+
+class CurrentUserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    """User retrieve and update viewsets for the current user"""
+
+    serializer_class = UserSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def get_object(self):
+        """Return the current request user"""
+        # NOTE: this may be a logged in or anonymous user
+        return self.request.user

--- a/users/views.py
+++ b/users/views.py
@@ -1,8 +1,12 @@
 """Views for the users app."""
 
+from django.shortcuts import redirect
+from django.urls import reverse
 from django.views.generic import TemplateView
-from rest_framework import mixins, viewsets
-from rest_framework.permissions import IsAuthenticated
+from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 
 from unified_ecommerce.serializers import UserSerializer
 
@@ -23,3 +27,44 @@ class CurrentUserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericView
         """Return the current request user"""
         # NOTE: this may be a logged in or anonymous user
         return self.request.user
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def session_check(request):
+    """
+    Check for an active user session.
+
+    If a session doesn't exist, then redirect the user to a route that requires
+    the APISIX middleware, so they can then have a session.
+    """
+
+    if request.user.is_authenticated:
+        return Response(UserSerializer(request.user).data, status=status.HTTP_200_OK)
+
+    next_url = (
+        request.GET["next"] if "next" in request.GET else reverse("users-session_check")
+    )
+
+    request.session["next"] = next_url
+
+    return Response(
+        {
+            "detail": "User is not authenticated",
+            "next": request.session.get("next", "/"),
+        },
+        status=status.HTTP_401_UNAUTHORIZED,
+    )
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def establish_session(request):
+    """Establish a session, then redirect to a "next" setting if there is one."""
+
+    next_url = (
+        request.GET["next"] if "next" in request.GET else reverse("users-session_check")
+    )
+    next_url = request.session.get("next", next_url)
+
+    return redirect(next_url)

--- a/users/views.py
+++ b/users/views.py
@@ -3,10 +3,9 @@
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.generic import TemplateView
-from rest_framework import mixins, status, viewsets
+from rest_framework import mixins, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
-from rest_framework.response import Response
 
 from unified_ecommerce.serializers import UserSerializer
 
@@ -21,40 +20,12 @@ class CurrentUserRetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericView
     """User retrieve and update viewsets for the current user"""
 
     serializer_class = UserSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (AllowAny,)
 
     def get_object(self):
         """Return the current request user"""
         # NOTE: this may be a logged in or anonymous user
         return self.request.user
-
-
-@api_view(["GET"])
-@permission_classes([AllowAny])
-def session_check(request):
-    """
-    Check for an active user session.
-
-    If a session doesn't exist, then redirect the user to a route that requires
-    the APISIX middleware, so they can then have a session.
-    """
-
-    if request.user.is_authenticated:
-        return Response(UserSerializer(request.user).data, status=status.HTTP_200_OK)
-
-    next_url = (
-        request.GET["next"] if "next" in request.GET else reverse("users-session_check")
-    )
-
-    request.session["next"] = next_url
-
-    return Response(
-        {
-            "detail": "User is not authenticated",
-            "next": request.session.get("next", "/"),
-        },
-        status=status.HTTP_401_UNAUTHORIZED,
-    )
 
 
 @api_view(["GET"])


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5656 

### Description (What does it do?)

This adds a handful of minor things to the auth and basket APIs:

- Adds logout route - this is the normal Django logout route, it's just now configured to work. (This is more for testing.)
- Adds a current user endpoint.
- Adds an `establish_session` endpoint - this gives the frontend a route to hit that will get the session set up, and then redirect the user back into the calling app. 
- Updates the `ApisixUserMiddleware` to subclass `PersistentRemoteUserMiddleware` to prevent sessions being lost when there's no APISIX headers
- Adds a filter to the `BasketViewSet` so we can retrieve baskets for a particular integrated system

### How can this be tested?

- You should be able to go to `<app root>/logout` and it should log you out. This should close your Keycloak session too.
- You should be able to go to `<app root/establish_session/` to test session establishment. This should bounce you through Keycloak if you're not already logged in.
   - Append `?next=<an url>` to have it drop you to a specific URL afterwards.  Otherwise, it should bounce you into the current user API.
- You should be able to specify the integrated system ID to the basket list API, and this should return just the baskets for the current user for that particular system. (Nothing has been released that uses this yet so this would be easiest to do via Swagger.)
