### PR TITLE
Adjusts routing to make sessions and authentication work better; fix logout

### DIFF
--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -8,20 +8,24 @@ routes:
   - id: 1
     name: "ue-unauth"
     desc: "Unauthenticated routes, including assets and checkout callback API"
-    priority: 0
+    priority: 1
     upstream_id: 1
-    plugins: {}
+    plugins:
+      cors:
+        allow_origins: "**"
+        allow_methods: "**"
+        allow_headers: "**"
+        allow_credential: true
+      response-rewrite:
+        headers:
+          set:
+            Referrer-Policy: "origin"
     uris:
-    - "/api/v0/payments/checkout/result/*"
-    - "/static/*"
-    - "/api/v0/schema/*"
-    - "/auth/*"
-    - "/_/v0/meta/apisix_test_request/"
-    - "/logged_out/"
+    - "/*"
   - id: 2
     name: "ue-default"
     desc: "Wildcard route for the rest of the system - authentication required"
-    priority: 1
+    priority: 0
     upstream_id: 1
     plugins:
       openid-connect:
@@ -45,6 +49,8 @@ routes:
           set:
             Referrer-Policy: "origin"
     uris:
-    - "/*"
+    - "/cart/*"
+    - "/admin/*"
+    - "/establish_session/*"
 
 #END

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -21,7 +21,12 @@ routes:
           set:
             Referrer-Policy: "origin"
     uris:
-    - "/*"
+    - "/api/*"
+    - "/_/*"
+    - "/logged_out/*"
+    - "/auth/*"
+    - "/static/*"
+    - "/favicon.ico"
   - id: 2
     name: "ue-default"
     desc: "Wildcard route for the rest of the system - authentication required"
@@ -37,7 +42,9 @@ routes:
         bearer_only: false
         introspection_endpoint_auth_method: "client_secret_post"
         ssl_verify: false
-        logout_path: "/logout/"
+        session:
+          secret: ${{SECRET_KEY}}
+        logout_path: "/logout"
         post_logout_redirect_uri: ${{UE_LOGOUT_URL}}
       cors:
         allow_origins: "**"
@@ -52,5 +59,15 @@ routes:
     - "/cart/*"
     - "/admin/*"
     - "/establish_session/*"
+    - "/logout"
+  - id: 3
+    name: "ue-logout-redirect"
+    desc: "Strip trailing slash from logout redirect."
+    priority: 0
+    upstream_id: 1
+    uri: "/logout/*"
+    plugins:
+      redirect:
+        uri: "/logout"
 
 #END

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,8 +76,7 @@ services:
       - django_media:/var/media
 
   api:
-    image: apache/apisix
-    platform: linux/amd64
+    image: apache/apisix:latest
     environment:
     - KEYCLOAK_REALM=${KEYCLOAK_REALM:-ol-local}
     - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID:-apisix}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
     - KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET}
     - KEYCLOAK_DISCOVERY_URL=${KEYCLOAK_DISCOVERY_URL:-https://kc.odl.local:7443/realms/ol-local/.well-known/openid-configuration}
     - APISIX_PORT=${APISIX_PORT:-9080}
+    - SECRET_KEY=${SECRET_KEY}
     - UE_LOGOUT_URL=${UE_LOGOUT_URL:-http://ue.odl.local:9080/auth/logout/}
     ports:
       - 9080:9080

--- a/unified_ecommerce/settings.py
+++ b/unified_ecommerce/settings.py
@@ -134,7 +134,7 @@ LOGIN_REDIRECT_URL = "/"
 LOGIN_URL = "/login"
 LOGIN_ERROR_URL = "/login"
 LOGOUT_URL = "/logout"
-LOGOUT_REDIRECT_URL = "/logged_out"
+LOGOUT_REDIRECT_URL = "/logged_out/"
 
 ROOT_URLCONF = "unified_ecommerce.urls"
 

--- a/users/views.py
+++ b/users/views.py
@@ -40,12 +40,14 @@ def establish_session(request):
     session check API endpoint.
     """
 
+    next_url = settings.MITOL_UE_PAYMENT_BASKET_CHOOSER
+
     if "next" in request.GET:
         try:
             system = IntegratedSystem.objects.get(slug=request.GET["next"])
             next_url = f"{settings.MITOL_UE_PAYMENT_BASKET_ROOT}{system.slug}/"
         except IntegratedSystem.DoesNotExist:
-            next_url = settings.MITOL_UE_PAYMENT_BASKET_CHOOSER
+            pass
 
     next_url = request.session.get("next", next_url)
 


### PR DESCRIPTION
### What are the relevant tickets?

mitodl/hq#5656

### Description (What does it do?)

The main thing this does is moves most of the routes _out_ of the configuration that requires OIDC. The app maintains a Django session, so that is sufficient, and having all the API routes run through the OIDC plugin mean that we end up with CORS errors and other weirdness when it invariably tries to punt the request through to Keycloak. 

The routes that are still set to use the OIDC plugin are:
- `/cart` - the cart test mule
- `/admin` - the Django Admin
- `/establish_ession` - establishes the session for a user (the frontend redirects here if you're not logged in)

The rest are located in the unauthenticated route. APISIX will not try to resolve a Keycloak session, which will leave the app to use the existing Django session if there is one. (Unauthenticated in this case is from the viewpoint of APISIX.)

This also fixes a couple other things:
- Now setting a session secret - evidently we were supposed to have this set; it just uses the Django secret key.
- Updated the OIDC config to send the user to the `UE_LOGOUT_URL` setting after logging out.
- Fixes logout so that it actually works now
   - Added an explicit route for `/logout` so that the OIDC plugin can intercept it. (Otherwise, the path doesn't match any known routes.) 
   - Added a new route to rewrite `/logout/` to `/logout` so both of these work.

### How can this be tested?

Set `UE_LOGOUT_URL` to a reasonable value: `UE_LOGOUT_URL=http://ue.odl.local:9080/auth/logout/`
This route specifically will clear the Django session.

1. Go to an API route that requires auth. (The basket list one is a good choice.) You shouldn't get anything back.
2. Go to an API route that _doesn't_ require auth. (The product list one is a good choice.) You should get data.
3. Set up a session. An easy way to do this is to just go to the cart test mule or to the Django Admin; both of these should redirect you through Keycloak. 
4. Check the "me" endpoint: `/api/v0/users/me/` You should see your account info.
5. Check other API routes. You should be able to get data from the authenticated and unauthenticated routes.
6. Go to `/logout` or `/logout/`. You should be redirect to whatever you have set for `UE_LOGOUT_URL` in your `.env`. 

### Additional Notes

Some notes for later use: APISIX's OIDC plugin will intercept a URI to handle logout properly (through the IdP). This URI is configurable, but doesn't support wildcards. Additionally, the URI needs to be in the URI set for the route that uses the OIDC plugin - it won't add it to the list. This is not necessarily noted anywhere so it was sort of confusing when it didn't work initially.

We may be able to continue to route the API requests through OIDC without forcing auth when the user doesn't have an APISIX session. This would allow us to capture account data changes - if the user adjusts their profile outside of UE, hitting the API would refresh their profile within UE too (which is how it works without these changes). However, the session is separate between routes I think so this may be more trouble than it's worth. We may instead want to use SCIM to sync user profile data into UE, like we do(?) elsewhere.