### PR TITLE
Adds an API to grab a basket based on current user and specified system

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,15 +175,6 @@
         "line_number": 1
       }
     ],
-    "docker-compose-apisix.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docker-compose-apisix.yml",
-        "hashed_secret": "965f383cb0ba71f9e9d33ae7eec9380590a4e9e3",
-        "is_verified": false,
-        "line_number": 43
-      }
-    ],
     "docker-compose.yml": [
       {
         "type": "Basic Auth Credentials",
@@ -194,5 +185,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-21T20:53:59Z"
+  "generated_at": "2024-12-05T14:34:37Z"
 }

--- a/cart/templates/cart.html
+++ b/cart/templates/cart.html
@@ -96,7 +96,9 @@
                 <select name="product" id="product">
                     <option></option>
                     {% for product in products %}
+                    {% if product.system.id == basket.integrated_system.id %}
                     <option value="{{ product.system.slug }}/{{ product.sku }}">{{ product.system.name }} - {{ product.name }} ${{ product.price }}</option>
+                    {% endif %}
                     {% endfor %}
                 </select>
             </div>

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -27,6 +27,7 @@ routes:
     - "/auth/*"
     - "/static/*"
     - "/favicon.ico"
+    - "/checkout/*"
   - id: 2
     name: "ue-default"
     desc: "Wildcard route for the rest of the system - authentication required"

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -104,6 +104,100 @@ export interface BasketWithProduct {
     'total_price': number;
 }
 /**
+ * Serializer for companies.
+ * @export
+ * @interface Company
+ */
+export interface Company {
+    /**
+     *
+     * @type {number}
+     * @memberof Company
+     */
+    'id': number;
+    /**
+     *
+     * @type {string}
+     * @memberof Company
+     */
+    'name': string;
+}
+/**
+ * Serializer for discounts.
+ * @export
+ * @interface Discount
+ */
+export interface Discount {
+    /**
+     *
+     * @type {number}
+     * @memberof Discount
+     */
+    'id': number;
+    /**
+     *
+     * @type {string}
+     * @memberof Discount
+     */
+    'discount_code': string;
+    /**
+     *
+     * @type {string}
+     * @memberof Discount
+     */
+    'amount': string;
+    /**
+     *
+     * @type {PaymentTypeEnum}
+     * @memberof Discount
+     */
+    'payment_type'?: PaymentTypeEnum | null;
+    /**
+     *
+     * @type {number}
+     * @memberof Discount
+     */
+    'max_redemptions'?: number | null;
+    /**
+     * If set, this discount code will not be redeemable before this date.
+     * @type {string}
+     * @memberof Discount
+     */
+    'activation_date'?: string | null;
+    /**
+     * If set, this discount code will not be redeemable after this date.
+     * @type {string}
+     * @memberof Discount
+     */
+    'expiration_date'?: string | null;
+    /**
+     *
+     * @type {IntegratedSystem}
+     * @memberof Discount
+     */
+    'integrated_system': IntegratedSystem;
+    /**
+     *
+     * @type {Product}
+     * @memberof Discount
+     */
+    'product': Product;
+    /**
+     *
+     * @type {Array<User>}
+     * @memberof Discount
+     */
+    'assigned_users': Array<User>;
+    /**
+     *
+     * @type {Company}
+     * @memberof Discount
+     */
+    'company': Company;
+}
+
+
+/**
  * Serializer for IntegratedSystem model.
  * @export
  * @interface IntegratedSystem
@@ -202,6 +296,23 @@ export interface Line {
      */
     'product': Product;
 }
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+
+export const NullEnumDescriptions = {
+    'null': "",
+} as const;
+
+export const NullEnum = {
+    Null: 'null'
+} as const;
+
+export type NullEnum = typeof NullEnum[keyof typeof NullEnum];
+
+
 /**
  * Serializer for order history.
  * @export
@@ -451,6 +562,61 @@ export interface PatchedProductRequest {
      */
     'price'?: string;
 }
+/**
+ * * `marketing` - marketing * `sales` - sales * `financial-assistance` - financial-assistance * `customer-support` - customer-support * `staff` - staff * `legacy` - legacy * `credit_card` - credit_card * `purchase_order` - purchase_order
+ * @export
+ * @enum {string}
+ */
+
+export const PaymentTypeEnumDescriptions = {
+    'marketing': "marketing",
+    'sales': "sales",
+    'financial-assistance': "financial-assistance",
+    'customer-support': "customer-support",
+    'staff': "staff",
+    'legacy': "legacy",
+    'credit_card': "credit_card",
+    'purchase_order': "purchase_order",
+} as const;
+
+export const PaymentTypeEnum = {
+    /**
+    * marketing
+    */
+    Marketing: 'marketing',
+    /**
+    * sales
+    */
+    Sales: 'sales',
+    /**
+    * financial-assistance
+    */
+    FinancialAssistance: 'financial-assistance',
+    /**
+    * customer-support
+    */
+    CustomerSupport: 'customer-support',
+    /**
+    * staff
+    */
+    Staff: 'staff',
+    /**
+    * legacy
+    */
+    Legacy: 'legacy',
+    /**
+    * credit_card
+    */
+    CreditCard: 'credit_card',
+    /**
+    * purchase_order
+    */
+    PurchaseOrder: 'purchase_order'
+} as const;
+
+export type PaymentTypeEnum = typeof PaymentTypeEnum[keyof typeof PaymentTypeEnum];
+
+
 /**
  * Serializer for Product model.
  * @export
@@ -1844,6 +2010,39 @@ export const PaymentsApiAxiosParamCreator = function (configuration?: Configurat
             };
         },
         /**
+         * Returns or creates a basket for the current user and system.
+         * @param {string} system_slug
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        paymentsBasketsForSystemRetrieve: async (system_slug: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'system_slug' is not null or undefined
+            assertParamExists('paymentsBasketsForSystemRetrieve', 'system_slug', system_slug)
+            const localVarPath = `/api/v0/payments/baskets/for_system/{system_slug}/`
+                .replace(`{${"system_slug"}}`, encodeURIComponent(String(system_slug)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Retrives the current user\'s baskets, one per system.
          * @param {number} [integrated_system]
          * @param {number} [limit] Number of results to return per page.
@@ -1906,6 +2105,35 @@ export const PaymentsApiAxiosParamCreator = function (configuration?: Configurat
             }
 
             const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Create a discount.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        paymentsDiscountsCreate: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v0/payments/discounts/`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
@@ -2040,6 +2268,18 @@ export const PaymentsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
         },
         /**
+         * Returns or creates a basket for the current user and system.
+         * @param {string} system_slug
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async paymentsBasketsForSystemRetrieve(system_slug: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<BasketWithProduct>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.paymentsBasketsForSystemRetrieve(system_slug, options);
+            const index = configuration?.serverIndex ?? 0;
+            const operationBasePath = operationServerMap['PaymentsApi.paymentsBasketsForSystemRetrieve']?.[index]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
+        },
+        /**
          * Retrives the current user\'s baskets, one per system.
          * @param {number} [integrated_system]
          * @param {number} [limit] Number of results to return per page.
@@ -2063,6 +2303,17 @@ export const PaymentsApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.paymentsBasketsRetrieve(id, options);
             const index = configuration?.serverIndex ?? 0;
             const operationBasePath = operationServerMap['PaymentsApi.paymentsBasketsRetrieve']?.[index]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
+        },
+        /**
+         * Create a discount.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async paymentsDiscountsCreate(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Discount>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.paymentsDiscountsCreate(options);
+            const index = configuration?.serverIndex ?? 0;
+            const operationBasePath = operationServerMap['PaymentsApi.paymentsDiscountsCreate']?.[index]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
         },
         /**
@@ -2128,6 +2379,15 @@ export const PaymentsApiFactory = function (configuration?: Configuration, baseP
             return localVarFp.paymentsBasketsCreateFromProductCreate(requestParameters.sku, requestParameters.system_slug, options).then((request) => request(axios, basePath));
         },
         /**
+         * Returns or creates a basket for the current user and system.
+         * @param {PaymentsApiPaymentsBasketsForSystemRetrieveRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        paymentsBasketsForSystemRetrieve(requestParameters: PaymentsApiPaymentsBasketsForSystemRetrieveRequest, options?: RawAxiosRequestConfig): AxiosPromise<BasketWithProduct> {
+            return localVarFp.paymentsBasketsForSystemRetrieve(requestParameters.system_slug, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Retrives the current user\'s baskets, one per system.
          * @param {PaymentsApiPaymentsBasketsListRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
@@ -2144,6 +2404,14 @@ export const PaymentsApiFactory = function (configuration?: Configuration, baseP
          */
         paymentsBasketsRetrieve(requestParameters: PaymentsApiPaymentsBasketsRetrieveRequest, options?: RawAxiosRequestConfig): AxiosPromise<BasketWithProduct> {
             return localVarFp.paymentsBasketsRetrieve(requestParameters.id, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * Create a discount.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        paymentsDiscountsCreate(options?: RawAxiosRequestConfig): AxiosPromise<Discount> {
+            return localVarFp.paymentsDiscountsCreate(options).then((request) => request(axios, basePath));
         },
         /**
          * Retrives the current user\'s completed orders.
@@ -2211,6 +2479,20 @@ export interface PaymentsApiPaymentsBasketsCreateFromProductCreateRequest {
      *
      * @type {string}
      * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate
+     */
+    readonly system_slug: string
+}
+
+/**
+ * Request parameters for paymentsBasketsForSystemRetrieve operation in PaymentsApi.
+ * @export
+ * @interface PaymentsApiPaymentsBasketsForSystemRetrieveRequest
+ */
+export interface PaymentsApiPaymentsBasketsForSystemRetrieveRequest {
+    /**
+     *
+     * @type {string}
+     * @memberof PaymentsApiPaymentsBasketsForSystemRetrieve
      */
     readonly system_slug: string
 }
@@ -2333,6 +2615,17 @@ export class PaymentsApi extends BaseAPI {
     }
 
     /**
+     * Returns or creates a basket for the current user and system.
+     * @param {PaymentsApiPaymentsBasketsForSystemRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PaymentsApi
+     */
+    public paymentsBasketsForSystemRetrieve(requestParameters: PaymentsApiPaymentsBasketsForSystemRetrieveRequest, options?: RawAxiosRequestConfig) {
+        return PaymentsApiFp(this.configuration).paymentsBasketsForSystemRetrieve(requestParameters.system_slug, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
      * Retrives the current user\'s baskets, one per system.
      * @param {PaymentsApiPaymentsBasketsListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -2352,6 +2645,16 @@ export class PaymentsApi extends BaseAPI {
      */
     public paymentsBasketsRetrieve(requestParameters: PaymentsApiPaymentsBasketsRetrieveRequest, options?: RawAxiosRequestConfig) {
         return PaymentsApiFp(this.configuration).paymentsBasketsRetrieve(requestParameters.id, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Create a discount.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PaymentsApi
+     */
+    public paymentsDiscountsCreate(options?: RawAxiosRequestConfig) {
+        return PaymentsApiFp(this.configuration).paymentsDiscountsCreate(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -413,6 +413,25 @@ paths:
               schema:
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
+  /api/v0/payments/baskets/for_system/{system_slug}/:
+    get:
+      operationId: payments_baskets_for_system_retrieve
+      description: Returns or creates a basket for the current user and system.
+      parameters:
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - payments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -101,6 +101,32 @@ class BasketViewSet(ReadOnlyModelViewSet):
 
 
 @extend_schema(
+    description="Returns or creates a basket for the current user and system.",
+    methods=["GET"],
+    request=None,
+    responses=BasketWithProductSerializer,
+)
+@api_view(["GET"])
+@permission_classes((IsAuthenticated,))
+def get_user_basket_for_system(request, system_slug: str):
+    """
+    Return the user's basket for the given system.
+
+    Args:
+        request: The request object.
+        system_slug: The system slug.
+
+    Returns:
+        Basket: The basket object.
+    """
+    system = IntegratedSystem.objects.get(slug=system_slug)
+    return Response(
+        BasketWithProductSerializer(Basket.establish_basket(request, system)).data,
+        status=status.HTTP_200_OK,
+    )
+
+
+@extend_schema(
     description=(
         "Creates or updates a basket for the current user, "
         "adding the selected product."

--- a/payments/views/v0/urls.py
+++ b/payments/views/v0/urls.py
@@ -12,6 +12,7 @@ from payments.views.v0 import (
     add_discount_to_basket,
     clear_basket,
     create_basket_from_product,
+    get_user_basket_for_system,
 )
 from unified_ecommerce.routers import SimpleRouterWithNesting
 
@@ -24,6 +25,11 @@ router.register(r"orders/history", OrderHistoryViewSet, basename="orderhistory_a
 router.register(r"checkout", CheckoutApiViewSet, basename="checkout")
 
 urlpatterns = [
+    path(
+        "baskets/for_system/<str:system_slug>/",
+        get_user_basket_for_system,
+        name="get_user_basket_for_system",
+    ),
     path(
         "baskets/create_from_product/<str:system_slug>/<str:sku>/",
         create_basket_from_product,

--- a/users/views.py
+++ b/users/views.py
@@ -1,5 +1,7 @@
 """Views for the users app."""
 
+from urllib.parse import urljoin
+
 from django.conf import settings
 from django.shortcuts import redirect
 from django.views.generic import TemplateView
@@ -45,7 +47,9 @@ def establish_session(request):
     if "next" in request.GET:
         try:
             system = IntegratedSystem.objects.get(slug=request.GET["next"])
-            next_url = f"{settings.MITOL_UE_PAYMENT_BASKET_ROOT}{system.slug}/"
+            next_url = urljoin(
+                settings.MITOL_UE_PAYMENT_BASKET_ROOT, f"?system={system.slug}"
+            )
         except IntegratedSystem.DoesNotExist:
             pass
 


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5656

### Description (What does it do?)

- Update secrets baseline.
- Update the establish_session to use `urljoin` rather than an f-string.
- Add a "get_user_basket_for_system" so we can retrieve a user's basket by the integrated system more easily. (This also creates the basket if it needs to, which it might.)
- Updates APISIX routes to include `/checkout` (this one got missed)
- Updates the cart test mule to filter products based on the basket you're looking at's system

### How can this be tested?

Tests should pass.

Hitting the API should work as expected. If you don't already have a basket for the specified system, one should be created for you.

### Additional Context

It doesn't really hurt to have empty baskets floating around out there for a user. Without this, we have to grab a list of all the user's baskets, then conditionally get a specific basket based on what cart we're supposed to be looking at.