### PR TITLE
Updates to the backend to support the frontend

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -3537,10 +3537,10 @@ export const PaymentsApiAxiosParamCreator = function (configuration?: Configurat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        paymentsCheckoutStartCheckoutCreate: async (system_slug: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        paymentsCheckoutCreate: async (system_slug: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'system_slug' is not null or undefined
-            assertParamExists('paymentsCheckoutStartCheckoutCreate', 'system_slug', system_slug)
-            const localVarPath = `/api/v0/payments/checkout/start_checkout/`
+            assertParamExists('paymentsCheckoutCreate', 'system_slug', system_slug)
+            const localVarPath = `/api/v0/payments/checkout/{system_slug}/`
                 .replace(`{${"system_slug"}}`, encodeURIComponent(String(system_slug)));
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3757,10 +3757,10 @@ export const PaymentsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async paymentsCheckoutStartCheckoutCreate(system_slug: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CyberSourceCheckout>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.paymentsCheckoutStartCheckoutCreate(system_slug, options);
+        async paymentsCheckoutCreate(system_slug: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CyberSourceCheckout>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.paymentsCheckoutCreate(system_slug, options);
             const index = configuration?.serverIndex ?? 0;
-            const operationBasePath = operationServerMap['PaymentsApi.paymentsCheckoutStartCheckoutCreate']?.[index]?.url;
+            const operationBasePath = operationServerMap['PaymentsApi.paymentsCheckoutCreate']?.[index]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
         },
         /**
@@ -3865,12 +3865,12 @@ export const PaymentsApiFactory = function (configuration?: Configuration, baseP
         },
         /**
          * Generates and returns the form payload for the current basket for the specified system, which can be used to start the checkout process.
-         * @param {PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest} requestParameters Request parameters.
+         * @param {PaymentsApiPaymentsCheckoutCreateRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        paymentsCheckoutStartCheckoutCreate(requestParameters: PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest, options?: RawAxiosRequestConfig): AxiosPromise<CyberSourceCheckout> {
-            return localVarFp.paymentsCheckoutStartCheckoutCreate(requestParameters.system_slug, options).then((request) => request(axios, basePath));
+        paymentsCheckoutCreate(requestParameters: PaymentsApiPaymentsCheckoutCreateRequest, options?: RawAxiosRequestConfig): AxiosPromise<CyberSourceCheckout> {
+            return localVarFp.paymentsCheckoutCreate(requestParameters.system_slug, options).then((request) => request(axios, basePath));
         },
         /**
          * Create a discount.
@@ -4014,15 +4014,15 @@ export interface PaymentsApiPaymentsBasketsRetrieveRequest {
 }
 
 /**
- * Request parameters for paymentsCheckoutStartCheckoutCreate operation in PaymentsApi.
+ * Request parameters for paymentsCheckoutCreate operation in PaymentsApi.
  * @export
- * @interface PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest
+ * @interface PaymentsApiPaymentsCheckoutCreateRequest
  */
-export interface PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest {
+export interface PaymentsApiPaymentsCheckoutCreateRequest {
     /**
      *
      * @type {string}
-     * @memberof PaymentsApiPaymentsCheckoutStartCheckoutCreate
+     * @memberof PaymentsApiPaymentsCheckoutCreate
      */
     readonly system_slug: string
 }
@@ -4137,13 +4137,13 @@ export class PaymentsApi extends BaseAPI {
 
     /**
      * Generates and returns the form payload for the current basket for the specified system, which can be used to start the checkout process.
-     * @param {PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest} requestParameters Request parameters.
+     * @param {PaymentsApiPaymentsCheckoutCreateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof PaymentsApi
      */
-    public paymentsCheckoutStartCheckoutCreate(requestParameters: PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest, options?: RawAxiosRequestConfig) {
-        return PaymentsApiFp(this.configuration).paymentsCheckoutStartCheckoutCreate(requestParameters.system_slug, options).then((request) => request(this.axios, this.basePath));
+    public paymentsCheckoutCreate(requestParameters: PaymentsApiPaymentsCheckoutCreateRequest, options?: RawAxiosRequestConfig) {
+        return PaymentsApiFp(this.configuration).paymentsCheckoutCreate(requestParameters.system_slug, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -53,6 +53,18 @@ export interface BasketItemWithProduct {
      * @memberof BasketItemWithProduct
      */
     'discounted_price': number;
+    /**
+     *
+     * @type {number}
+     * @memberof BasketItemWithProduct
+     */
+    'quantity'?: number;
+    /**
+     *
+     * @type {SimpleDiscount}
+     * @memberof BasketItemWithProduct
+     */
+    'discount_applied': SimpleDiscount;
 }
 /**
  * Basket model serializer with items and products
@@ -97,6 +109,12 @@ export interface BasketWithProduct {
      */
     'tax': number;
     /**
+     *
+     * @type {TaxRate}
+     * @memberof BasketWithProduct
+     */
+    'tax_rate': TaxRate;
+    /**
      * Get the total price for the basket
      * @type {number}
      * @memberof BasketWithProduct
@@ -121,6 +139,1291 @@ export interface Company {
      * @memberof Company
      */
     'name': string;
+}
+/**
+ * * `AF` - Afghanistan * `AX` - Åland Islands * `AL` - Albania * `DZ` - Algeria * `AS` - American Samoa * `AD` - Andorra * `AO` - Angola * `AI` - Anguilla * `AQ` - Antarctica * `AG` - Antigua and Barbuda * `AR` - Argentina * `AM` - Armenia * `AW` - Aruba * `AU` - Australia * `AT` - Austria * `AZ` - Azerbaijan * `BS` - Bahamas * `BH` - Bahrain * `BD` - Bangladesh * `BB` - Barbados * `BY` - Belarus * `BE` - Belgium * `BZ` - Belize * `BJ` - Benin * `BM` - Bermuda * `BT` - Bhutan * `BO` - Bolivia * `BQ` - Bonaire, Sint Eustatius and Saba * `BA` - Bosnia and Herzegovina * `BW` - Botswana * `BV` - Bouvet Island * `BR` - Brazil * `IO` - British Indian Ocean Territory * `BN` - Brunei * `BG` - Bulgaria * `BF` - Burkina Faso * `BI` - Burundi * `CV` - Cabo Verde * `KH` - Cambodia * `CM` - Cameroon * `CA` - Canada * `KY` - Cayman Islands * `CF` - Central African Republic * `TD` - Chad * `CL` - Chile * `CN` - China * `CX` - Christmas Island * `CC` - Cocos (Keeling) Islands * `CO` - Colombia * `KM` - Comoros * `CG` - Congo * `CD` - Congo (the Democratic Republic of the) * `CK` - Cook Islands * `CR` - Costa Rica * `CI` - Côte d\'Ivoire * `HR` - Croatia * `CU` - Cuba * `CW` - Curaçao * `CY` - Cyprus * `CZ` - Czechia * `DK` - Denmark * `DJ` - Djibouti * `DM` - Dominica * `DO` - Dominican Republic * `EC` - Ecuador * `EG` - Egypt * `SV` - El Salvador * `GQ` - Equatorial Guinea * `ER` - Eritrea * `EE` - Estonia * `SZ` - Eswatini * `ET` - Ethiopia * `FK` - Falkland Islands (Malvinas) * `FO` - Faroe Islands * `FJ` - Fiji * `FI` - Finland * `FR` - France * `GF` - French Guiana * `PF` - French Polynesia * `TF` - French Southern Territories * `GA` - Gabon * `GM` - Gambia * `GE` - Georgia * `DE` - Germany * `GH` - Ghana * `GI` - Gibraltar * `GR` - Greece * `GL` - Greenland * `GD` - Grenada * `GP` - Guadeloupe * `GU` - Guam * `GT` - Guatemala * `GG` - Guernsey * `GN` - Guinea * `GW` - Guinea-Bissau * `GY` - Guyana * `HT` - Haiti * `HM` - Heard Island and McDonald Islands * `VA` - Holy See * `HN` - Honduras * `HK` - Hong Kong * `HU` - Hungary * `IS` - Iceland * `IN` - India * `ID` - Indonesia * `IR` - Iran * `IQ` - Iraq * `IE` - Ireland * `IM` - Isle of Man * `IL` - Israel * `IT` - Italy * `JM` - Jamaica * `JP` - Japan * `JE` - Jersey * `JO` - Jordan * `KZ` - Kazakhstan * `KE` - Kenya * `KI` - Kiribati * `KW` - Kuwait * `KG` - Kyrgyzstan * `LA` - Laos * `LV` - Latvia * `LB` - Lebanon * `LS` - Lesotho * `LR` - Liberia * `LY` - Libya * `LI` - Liechtenstein * `LT` - Lithuania * `LU` - Luxembourg * `MO` - Macao * `MG` - Madagascar * `MW` - Malawi * `MY` - Malaysia * `MV` - Maldives * `ML` - Mali * `MT` - Malta * `MH` - Marshall Islands * `MQ` - Martinique * `MR` - Mauritania * `MU` - Mauritius * `YT` - Mayotte * `MX` - Mexico * `FM` - Micronesia * `MD` - Moldova * `MC` - Monaco * `MN` - Mongolia * `ME` - Montenegro * `MS` - Montserrat * `MA` - Morocco * `MZ` - Mozambique * `MM` - Myanmar * `NA` - Namibia * `NR` - Nauru * `NP` - Nepal * `NL` - Netherlands * `NC` - New Caledonia * `NZ` - New Zealand * `NI` - Nicaragua * `NE` - Niger * `NG` - Nigeria * `NU` - Niue * `NF` - Norfolk Island * `KP` - North Korea * `MK` - North Macedonia * `MP` - Northern Mariana Islands * `NO` - Norway * `OM` - Oman * `PK` - Pakistan * `PW` - Palau * `PS` - Palestine, State of * `PA` - Panama * `PG` - Papua New Guinea * `PY` - Paraguay * `PE` - Peru * `PH` - Philippines * `PN` - Pitcairn * `PL` - Poland * `PT` - Portugal * `PR` - Puerto Rico * `QA` - Qatar * `RE` - Réunion * `RO` - Romania * `RU` - Russia * `RW` - Rwanda * `BL` - Saint Barthélemy * `SH` - Saint Helena, Ascension and Tristan da Cunha * `KN` - Saint Kitts and Nevis * `LC` - Saint Lucia * `MF` - Saint Martin (French part) * `PM` - Saint Pierre and Miquelon * `VC` - Saint Vincent and the Grenadines * `WS` - Samoa * `SM` - San Marino * `ST` - Sao Tome and Principe * `SA` - Saudi Arabia * `SN` - Senegal * `RS` - Serbia * `SC` - Seychelles * `SL` - Sierra Leone * `SG` - Singapore * `SX` - Sint Maarten (Dutch part) * `SK` - Slovakia * `SI` - Slovenia * `SB` - Solomon Islands * `SO` - Somalia * `ZA` - South Africa * `GS` - South Georgia and the South Sandwich Islands * `KR` - South Korea * `SS` - South Sudan * `ES` - Spain * `LK` - Sri Lanka * `SD` - Sudan * `SR` - Suriname * `SJ` - Svalbard and Jan Mayen * `SE` - Sweden * `CH` - Switzerland * `SY` - Syria * `TW` - Taiwan * `TJ` - Tajikistan * `TZ` - Tanzania * `TH` - Thailand * `TL` - Timor-Leste * `TG` - Togo * `TK` - Tokelau * `TO` - Tonga * `TT` - Trinidad and Tobago * `TN` - Tunisia * `TR` - Türkiye * `TM` - Turkmenistan * `TC` - Turks and Caicos Islands * `TV` - Tuvalu * `UG` - Uganda * `UA` - Ukraine * `AE` - United Arab Emirates * `GB` - United Kingdom * `UM` - United States Minor Outlying Islands * `US` - United States of America * `UY` - Uruguay * `UZ` - Uzbekistan * `VU` - Vanuatu * `VE` - Venezuela * `VN` - Vietnam * `VG` - Virgin Islands (British) * `VI` - Virgin Islands (U.S.) * `WF` - Wallis and Futuna * `EH` - Western Sahara * `YE` - Yemen * `ZM` - Zambia * `ZW` - Zimbabwe
+ * @export
+ * @enum {string}
+ */
+
+export const CountryCodeEnumDescriptions = {
+    'AF': "Afghanistan",
+    'AX': "Åland Islands",
+    'AL': "Albania",
+    'DZ': "Algeria",
+    'AS': "American Samoa",
+    'AD': "Andorra",
+    'AO': "Angola",
+    'AI': "Anguilla",
+    'AQ': "Antarctica",
+    'AG': "Antigua and Barbuda",
+    'AR': "Argentina",
+    'AM': "Armenia",
+    'AW': "Aruba",
+    'AU': "Australia",
+    'AT': "Austria",
+    'AZ': "Azerbaijan",
+    'BS': "Bahamas",
+    'BH': "Bahrain",
+    'BD': "Bangladesh",
+    'BB': "Barbados",
+    'BY': "Belarus",
+    'BE': "Belgium",
+    'BZ': "Belize",
+    'BJ': "Benin",
+    'BM': "Bermuda",
+    'BT': "Bhutan",
+    'BO': "Bolivia",
+    'BQ': "Bonaire, Sint Eustatius and Saba",
+    'BA': "Bosnia and Herzegovina",
+    'BW': "Botswana",
+    'BV': "Bouvet Island",
+    'BR': "Brazil",
+    'IO': "British Indian Ocean Territory",
+    'BN': "Brunei",
+    'BG': "Bulgaria",
+    'BF': "Burkina Faso",
+    'BI': "Burundi",
+    'CV': "Cabo Verde",
+    'KH': "Cambodia",
+    'CM': "Cameroon",
+    'CA': "Canada",
+    'KY': "Cayman Islands",
+    'CF': "Central African Republic",
+    'TD': "Chad",
+    'CL': "Chile",
+    'CN': "China",
+    'CX': "Christmas Island",
+    'CC': "Cocos (Keeling) Islands",
+    'CO': "Colombia",
+    'KM': "Comoros",
+    'CG': "Congo",
+    'CD': "Congo (the Democratic Republic of the)",
+    'CK': "Cook Islands",
+    'CR': "Costa Rica",
+    'CI': "Côte d'Ivoire",
+    'HR': "Croatia",
+    'CU': "Cuba",
+    'CW': "Curaçao",
+    'CY': "Cyprus",
+    'CZ': "Czechia",
+    'DK': "Denmark",
+    'DJ': "Djibouti",
+    'DM': "Dominica",
+    'DO': "Dominican Republic",
+    'EC': "Ecuador",
+    'EG': "Egypt",
+    'SV': "El Salvador",
+    'GQ': "Equatorial Guinea",
+    'ER': "Eritrea",
+    'EE': "Estonia",
+    'SZ': "Eswatini",
+    'ET': "Ethiopia",
+    'FK': "Falkland Islands (Malvinas)",
+    'FO': "Faroe Islands",
+    'FJ': "Fiji",
+    'FI': "Finland",
+    'FR': "France",
+    'GF': "French Guiana",
+    'PF': "French Polynesia",
+    'TF': "French Southern Territories",
+    'GA': "Gabon",
+    'GM': "Gambia",
+    'GE': "Georgia",
+    'DE': "Germany",
+    'GH': "Ghana",
+    'GI': "Gibraltar",
+    'GR': "Greece",
+    'GL': "Greenland",
+    'GD': "Grenada",
+    'GP': "Guadeloupe",
+    'GU': "Guam",
+    'GT': "Guatemala",
+    'GG': "Guernsey",
+    'GN': "Guinea",
+    'GW': "Guinea-Bissau",
+    'GY': "Guyana",
+    'HT': "Haiti",
+    'HM': "Heard Island and McDonald Islands",
+    'VA': "Holy See",
+    'HN': "Honduras",
+    'HK': "Hong Kong",
+    'HU': "Hungary",
+    'IS': "Iceland",
+    'IN': "India",
+    'ID': "Indonesia",
+    'IR': "Iran",
+    'IQ': "Iraq",
+    'IE': "Ireland",
+    'IM': "Isle of Man",
+    'IL': "Israel",
+    'IT': "Italy",
+    'JM': "Jamaica",
+    'JP': "Japan",
+    'JE': "Jersey",
+    'JO': "Jordan",
+    'KZ': "Kazakhstan",
+    'KE': "Kenya",
+    'KI': "Kiribati",
+    'KW': "Kuwait",
+    'KG': "Kyrgyzstan",
+    'LA': "Laos",
+    'LV': "Latvia",
+    'LB': "Lebanon",
+    'LS': "Lesotho",
+    'LR': "Liberia",
+    'LY': "Libya",
+    'LI': "Liechtenstein",
+    'LT': "Lithuania",
+    'LU': "Luxembourg",
+    'MO': "Macao",
+    'MG': "Madagascar",
+    'MW': "Malawi",
+    'MY': "Malaysia",
+    'MV': "Maldives",
+    'ML': "Mali",
+    'MT': "Malta",
+    'MH': "Marshall Islands",
+    'MQ': "Martinique",
+    'MR': "Mauritania",
+    'MU': "Mauritius",
+    'YT': "Mayotte",
+    'MX': "Mexico",
+    'FM': "Micronesia",
+    'MD': "Moldova",
+    'MC': "Monaco",
+    'MN': "Mongolia",
+    'ME': "Montenegro",
+    'MS': "Montserrat",
+    'MA': "Morocco",
+    'MZ': "Mozambique",
+    'MM': "Myanmar",
+    'NA': "Namibia",
+    'NR': "Nauru",
+    'NP': "Nepal",
+    'NL': "Netherlands",
+    'NC': "New Caledonia",
+    'NZ': "New Zealand",
+    'NI': "Nicaragua",
+    'NE': "Niger",
+    'NG': "Nigeria",
+    'NU': "Niue",
+    'NF': "Norfolk Island",
+    'KP': "North Korea",
+    'MK': "North Macedonia",
+    'MP': "Northern Mariana Islands",
+    'NO': "Norway",
+    'OM': "Oman",
+    'PK': "Pakistan",
+    'PW': "Palau",
+    'PS': "Palestine, State of",
+    'PA': "Panama",
+    'PG': "Papua New Guinea",
+    'PY': "Paraguay",
+    'PE': "Peru",
+    'PH': "Philippines",
+    'PN': "Pitcairn",
+    'PL': "Poland",
+    'PT': "Portugal",
+    'PR': "Puerto Rico",
+    'QA': "Qatar",
+    'RE': "Réunion",
+    'RO': "Romania",
+    'RU': "Russia",
+    'RW': "Rwanda",
+    'BL': "Saint Barthélemy",
+    'SH': "Saint Helena, Ascension and Tristan da Cunha",
+    'KN': "Saint Kitts and Nevis",
+    'LC': "Saint Lucia",
+    'MF': "Saint Martin (French part)",
+    'PM': "Saint Pierre and Miquelon",
+    'VC': "Saint Vincent and the Grenadines",
+    'WS': "Samoa",
+    'SM': "San Marino",
+    'ST': "Sao Tome and Principe",
+    'SA': "Saudi Arabia",
+    'SN': "Senegal",
+    'RS': "Serbia",
+    'SC': "Seychelles",
+    'SL': "Sierra Leone",
+    'SG': "Singapore",
+    'SX': "Sint Maarten (Dutch part)",
+    'SK': "Slovakia",
+    'SI': "Slovenia",
+    'SB': "Solomon Islands",
+    'SO': "Somalia",
+    'ZA': "South Africa",
+    'GS': "South Georgia and the South Sandwich Islands",
+    'KR': "South Korea",
+    'SS': "South Sudan",
+    'ES': "Spain",
+    'LK': "Sri Lanka",
+    'SD': "Sudan",
+    'SR': "Suriname",
+    'SJ': "Svalbard and Jan Mayen",
+    'SE': "Sweden",
+    'CH': "Switzerland",
+    'SY': "Syria",
+    'TW': "Taiwan",
+    'TJ': "Tajikistan",
+    'TZ': "Tanzania",
+    'TH': "Thailand",
+    'TL': "Timor-Leste",
+    'TG': "Togo",
+    'TK': "Tokelau",
+    'TO': "Tonga",
+    'TT': "Trinidad and Tobago",
+    'TN': "Tunisia",
+    'TR': "Türkiye",
+    'TM': "Turkmenistan",
+    'TC': "Turks and Caicos Islands",
+    'TV': "Tuvalu",
+    'UG': "Uganda",
+    'UA': "Ukraine",
+    'AE': "United Arab Emirates",
+    'GB': "United Kingdom",
+    'UM': "United States Minor Outlying Islands",
+    'US': "United States of America",
+    'UY': "Uruguay",
+    'UZ': "Uzbekistan",
+    'VU': "Vanuatu",
+    'VE': "Venezuela",
+    'VN': "Vietnam",
+    'VG': "Virgin Islands (British)",
+    'VI': "Virgin Islands (U.S.)",
+    'WF': "Wallis and Futuna",
+    'EH': "Western Sahara",
+    'YE': "Yemen",
+    'ZM': "Zambia",
+    'ZW': "Zimbabwe",
+} as const;
+
+export const CountryCodeEnum = {
+    /**
+    * Afghanistan
+    */
+    Af: 'AF',
+    /**
+    * Åland Islands
+    */
+    Ax: 'AX',
+    /**
+    * Albania
+    */
+    Al: 'AL',
+    /**
+    * Algeria
+    */
+    Dz: 'DZ',
+    /**
+    * American Samoa
+    */
+    As: 'AS',
+    /**
+    * Andorra
+    */
+    Ad: 'AD',
+    /**
+    * Angola
+    */
+    Ao: 'AO',
+    /**
+    * Anguilla
+    */
+    Ai: 'AI',
+    /**
+    * Antarctica
+    */
+    Aq: 'AQ',
+    /**
+    * Antigua and Barbuda
+    */
+    Ag: 'AG',
+    /**
+    * Argentina
+    */
+    Ar: 'AR',
+    /**
+    * Armenia
+    */
+    Am: 'AM',
+    /**
+    * Aruba
+    */
+    Aw: 'AW',
+    /**
+    * Australia
+    */
+    Au: 'AU',
+    /**
+    * Austria
+    */
+    At: 'AT',
+    /**
+    * Azerbaijan
+    */
+    Az: 'AZ',
+    /**
+    * Bahamas
+    */
+    Bs: 'BS',
+    /**
+    * Bahrain
+    */
+    Bh: 'BH',
+    /**
+    * Bangladesh
+    */
+    Bd: 'BD',
+    /**
+    * Barbados
+    */
+    Bb: 'BB',
+    /**
+    * Belarus
+    */
+    By: 'BY',
+    /**
+    * Belgium
+    */
+    Be: 'BE',
+    /**
+    * Belize
+    */
+    Bz: 'BZ',
+    /**
+    * Benin
+    */
+    Bj: 'BJ',
+    /**
+    * Bermuda
+    */
+    Bm: 'BM',
+    /**
+    * Bhutan
+    */
+    Bt: 'BT',
+    /**
+    * Bolivia
+    */
+    Bo: 'BO',
+    /**
+    * Bonaire, Sint Eustatius and Saba
+    */
+    Bq: 'BQ',
+    /**
+    * Bosnia and Herzegovina
+    */
+    Ba: 'BA',
+    /**
+    * Botswana
+    */
+    Bw: 'BW',
+    /**
+    * Bouvet Island
+    */
+    Bv: 'BV',
+    /**
+    * Brazil
+    */
+    Br: 'BR',
+    /**
+    * British Indian Ocean Territory
+    */
+    Io: 'IO',
+    /**
+    * Brunei
+    */
+    Bn: 'BN',
+    /**
+    * Bulgaria
+    */
+    Bg: 'BG',
+    /**
+    * Burkina Faso
+    */
+    Bf: 'BF',
+    /**
+    * Burundi
+    */
+    Bi: 'BI',
+    /**
+    * Cabo Verde
+    */
+    Cv: 'CV',
+    /**
+    * Cambodia
+    */
+    Kh: 'KH',
+    /**
+    * Cameroon
+    */
+    Cm: 'CM',
+    /**
+    * Canada
+    */
+    Ca: 'CA',
+    /**
+    * Cayman Islands
+    */
+    Ky: 'KY',
+    /**
+    * Central African Republic
+    */
+    Cf: 'CF',
+    /**
+    * Chad
+    */
+    Td: 'TD',
+    /**
+    * Chile
+    */
+    Cl: 'CL',
+    /**
+    * China
+    */
+    Cn: 'CN',
+    /**
+    * Christmas Island
+    */
+    Cx: 'CX',
+    /**
+    * Cocos (Keeling) Islands
+    */
+    Cc: 'CC',
+    /**
+    * Colombia
+    */
+    Co: 'CO',
+    /**
+    * Comoros
+    */
+    Km: 'KM',
+    /**
+    * Congo
+    */
+    Cg: 'CG',
+    /**
+    * Congo (the Democratic Republic of the)
+    */
+    Cd: 'CD',
+    /**
+    * Cook Islands
+    */
+    Ck: 'CK',
+    /**
+    * Costa Rica
+    */
+    Cr: 'CR',
+    /**
+    * Côte d&#39;Ivoire
+    */
+    Ci: 'CI',
+    /**
+    * Croatia
+    */
+    Hr: 'HR',
+    /**
+    * Cuba
+    */
+    Cu: 'CU',
+    /**
+    * Curaçao
+    */
+    Cw: 'CW',
+    /**
+    * Cyprus
+    */
+    Cy: 'CY',
+    /**
+    * Czechia
+    */
+    Cz: 'CZ',
+    /**
+    * Denmark
+    */
+    Dk: 'DK',
+    /**
+    * Djibouti
+    */
+    Dj: 'DJ',
+    /**
+    * Dominica
+    */
+    Dm: 'DM',
+    /**
+    * Dominican Republic
+    */
+    Do: 'DO',
+    /**
+    * Ecuador
+    */
+    Ec: 'EC',
+    /**
+    * Egypt
+    */
+    Eg: 'EG',
+    /**
+    * El Salvador
+    */
+    Sv: 'SV',
+    /**
+    * Equatorial Guinea
+    */
+    Gq: 'GQ',
+    /**
+    * Eritrea
+    */
+    Er: 'ER',
+    /**
+    * Estonia
+    */
+    Ee: 'EE',
+    /**
+    * Eswatini
+    */
+    Sz: 'SZ',
+    /**
+    * Ethiopia
+    */
+    Et: 'ET',
+    /**
+    * Falkland Islands (Malvinas)
+    */
+    Fk: 'FK',
+    /**
+    * Faroe Islands
+    */
+    Fo: 'FO',
+    /**
+    * Fiji
+    */
+    Fj: 'FJ',
+    /**
+    * Finland
+    */
+    Fi: 'FI',
+    /**
+    * France
+    */
+    Fr: 'FR',
+    /**
+    * French Guiana
+    */
+    Gf: 'GF',
+    /**
+    * French Polynesia
+    */
+    Pf: 'PF',
+    /**
+    * French Southern Territories
+    */
+    Tf: 'TF',
+    /**
+    * Gabon
+    */
+    Ga: 'GA',
+    /**
+    * Gambia
+    */
+    Gm: 'GM',
+    /**
+    * Georgia
+    */
+    Ge: 'GE',
+    /**
+    * Germany
+    */
+    De: 'DE',
+    /**
+    * Ghana
+    */
+    Gh: 'GH',
+    /**
+    * Gibraltar
+    */
+    Gi: 'GI',
+    /**
+    * Greece
+    */
+    Gr: 'GR',
+    /**
+    * Greenland
+    */
+    Gl: 'GL',
+    /**
+    * Grenada
+    */
+    Gd: 'GD',
+    /**
+    * Guadeloupe
+    */
+    Gp: 'GP',
+    /**
+    * Guam
+    */
+    Gu: 'GU',
+    /**
+    * Guatemala
+    */
+    Gt: 'GT',
+    /**
+    * Guernsey
+    */
+    Gg: 'GG',
+    /**
+    * Guinea
+    */
+    Gn: 'GN',
+    /**
+    * Guinea-Bissau
+    */
+    Gw: 'GW',
+    /**
+    * Guyana
+    */
+    Gy: 'GY',
+    /**
+    * Haiti
+    */
+    Ht: 'HT',
+    /**
+    * Heard Island and McDonald Islands
+    */
+    Hm: 'HM',
+    /**
+    * Holy See
+    */
+    Va: 'VA',
+    /**
+    * Honduras
+    */
+    Hn: 'HN',
+    /**
+    * Hong Kong
+    */
+    Hk: 'HK',
+    /**
+    * Hungary
+    */
+    Hu: 'HU',
+    /**
+    * Iceland
+    */
+    Is: 'IS',
+    /**
+    * India
+    */
+    In: 'IN',
+    /**
+    * Indonesia
+    */
+    Id: 'ID',
+    /**
+    * Iran
+    */
+    Ir: 'IR',
+    /**
+    * Iraq
+    */
+    Iq: 'IQ',
+    /**
+    * Ireland
+    */
+    Ie: 'IE',
+    /**
+    * Isle of Man
+    */
+    Im: 'IM',
+    /**
+    * Israel
+    */
+    Il: 'IL',
+    /**
+    * Italy
+    */
+    It: 'IT',
+    /**
+    * Jamaica
+    */
+    Jm: 'JM',
+    /**
+    * Japan
+    */
+    Jp: 'JP',
+    /**
+    * Jersey
+    */
+    Je: 'JE',
+    /**
+    * Jordan
+    */
+    Jo: 'JO',
+    /**
+    * Kazakhstan
+    */
+    Kz: 'KZ',
+    /**
+    * Kenya
+    */
+    Ke: 'KE',
+    /**
+    * Kiribati
+    */
+    Ki: 'KI',
+    /**
+    * Kuwait
+    */
+    Kw: 'KW',
+    /**
+    * Kyrgyzstan
+    */
+    Kg: 'KG',
+    /**
+    * Laos
+    */
+    La: 'LA',
+    /**
+    * Latvia
+    */
+    Lv: 'LV',
+    /**
+    * Lebanon
+    */
+    Lb: 'LB',
+    /**
+    * Lesotho
+    */
+    Ls: 'LS',
+    /**
+    * Liberia
+    */
+    Lr: 'LR',
+    /**
+    * Libya
+    */
+    Ly: 'LY',
+    /**
+    * Liechtenstein
+    */
+    Li: 'LI',
+    /**
+    * Lithuania
+    */
+    Lt: 'LT',
+    /**
+    * Luxembourg
+    */
+    Lu: 'LU',
+    /**
+    * Macao
+    */
+    Mo: 'MO',
+    /**
+    * Madagascar
+    */
+    Mg: 'MG',
+    /**
+    * Malawi
+    */
+    Mw: 'MW',
+    /**
+    * Malaysia
+    */
+    My: 'MY',
+    /**
+    * Maldives
+    */
+    Mv: 'MV',
+    /**
+    * Mali
+    */
+    Ml: 'ML',
+    /**
+    * Malta
+    */
+    Mt: 'MT',
+    /**
+    * Marshall Islands
+    */
+    Mh: 'MH',
+    /**
+    * Martinique
+    */
+    Mq: 'MQ',
+    /**
+    * Mauritania
+    */
+    Mr: 'MR',
+    /**
+    * Mauritius
+    */
+    Mu: 'MU',
+    /**
+    * Mayotte
+    */
+    Yt: 'YT',
+    /**
+    * Mexico
+    */
+    Mx: 'MX',
+    /**
+    * Micronesia
+    */
+    Fm: 'FM',
+    /**
+    * Moldova
+    */
+    Md: 'MD',
+    /**
+    * Monaco
+    */
+    Mc: 'MC',
+    /**
+    * Mongolia
+    */
+    Mn: 'MN',
+    /**
+    * Montenegro
+    */
+    Me: 'ME',
+    /**
+    * Montserrat
+    */
+    Ms: 'MS',
+    /**
+    * Morocco
+    */
+    Ma: 'MA',
+    /**
+    * Mozambique
+    */
+    Mz: 'MZ',
+    /**
+    * Myanmar
+    */
+    Mm: 'MM',
+    /**
+    * Namibia
+    */
+    Na: 'NA',
+    /**
+    * Nauru
+    */
+    Nr: 'NR',
+    /**
+    * Nepal
+    */
+    Np: 'NP',
+    /**
+    * Netherlands
+    */
+    Nl: 'NL',
+    /**
+    * New Caledonia
+    */
+    Nc: 'NC',
+    /**
+    * New Zealand
+    */
+    Nz: 'NZ',
+    /**
+    * Nicaragua
+    */
+    Ni: 'NI',
+    /**
+    * Niger
+    */
+    Ne: 'NE',
+    /**
+    * Nigeria
+    */
+    Ng: 'NG',
+    /**
+    * Niue
+    */
+    Nu: 'NU',
+    /**
+    * Norfolk Island
+    */
+    Nf: 'NF',
+    /**
+    * North Korea
+    */
+    Kp: 'KP',
+    /**
+    * North Macedonia
+    */
+    Mk: 'MK',
+    /**
+    * Northern Mariana Islands
+    */
+    Mp: 'MP',
+    /**
+    * Norway
+    */
+    No: 'NO',
+    /**
+    * Oman
+    */
+    Om: 'OM',
+    /**
+    * Pakistan
+    */
+    Pk: 'PK',
+    /**
+    * Palau
+    */
+    Pw: 'PW',
+    /**
+    * Palestine, State of
+    */
+    Ps: 'PS',
+    /**
+    * Panama
+    */
+    Pa: 'PA',
+    /**
+    * Papua New Guinea
+    */
+    Pg: 'PG',
+    /**
+    * Paraguay
+    */
+    Py: 'PY',
+    /**
+    * Peru
+    */
+    Pe: 'PE',
+    /**
+    * Philippines
+    */
+    Ph: 'PH',
+    /**
+    * Pitcairn
+    */
+    Pn: 'PN',
+    /**
+    * Poland
+    */
+    Pl: 'PL',
+    /**
+    * Portugal
+    */
+    Pt: 'PT',
+    /**
+    * Puerto Rico
+    */
+    Pr: 'PR',
+    /**
+    * Qatar
+    */
+    Qa: 'QA',
+    /**
+    * Réunion
+    */
+    Re: 'RE',
+    /**
+    * Romania
+    */
+    Ro: 'RO',
+    /**
+    * Russia
+    */
+    Ru: 'RU',
+    /**
+    * Rwanda
+    */
+    Rw: 'RW',
+    /**
+    * Saint Barthélemy
+    */
+    Bl: 'BL',
+    /**
+    * Saint Helena, Ascension and Tristan da Cunha
+    */
+    Sh: 'SH',
+    /**
+    * Saint Kitts and Nevis
+    */
+    Kn: 'KN',
+    /**
+    * Saint Lucia
+    */
+    Lc: 'LC',
+    /**
+    * Saint Martin (French part)
+    */
+    Mf: 'MF',
+    /**
+    * Saint Pierre and Miquelon
+    */
+    Pm: 'PM',
+    /**
+    * Saint Vincent and the Grenadines
+    */
+    Vc: 'VC',
+    /**
+    * Samoa
+    */
+    Ws: 'WS',
+    /**
+    * San Marino
+    */
+    Sm: 'SM',
+    /**
+    * Sao Tome and Principe
+    */
+    St: 'ST',
+    /**
+    * Saudi Arabia
+    */
+    Sa: 'SA',
+    /**
+    * Senegal
+    */
+    Sn: 'SN',
+    /**
+    * Serbia
+    */
+    Rs: 'RS',
+    /**
+    * Seychelles
+    */
+    Sc: 'SC',
+    /**
+    * Sierra Leone
+    */
+    Sl: 'SL',
+    /**
+    * Singapore
+    */
+    Sg: 'SG',
+    /**
+    * Sint Maarten (Dutch part)
+    */
+    Sx: 'SX',
+    /**
+    * Slovakia
+    */
+    Sk: 'SK',
+    /**
+    * Slovenia
+    */
+    Si: 'SI',
+    /**
+    * Solomon Islands
+    */
+    Sb: 'SB',
+    /**
+    * Somalia
+    */
+    So: 'SO',
+    /**
+    * South Africa
+    */
+    Za: 'ZA',
+    /**
+    * South Georgia and the South Sandwich Islands
+    */
+    Gs: 'GS',
+    /**
+    * South Korea
+    */
+    Kr: 'KR',
+    /**
+    * South Sudan
+    */
+    Ss: 'SS',
+    /**
+    * Spain
+    */
+    Es: 'ES',
+    /**
+    * Sri Lanka
+    */
+    Lk: 'LK',
+    /**
+    * Sudan
+    */
+    Sd: 'SD',
+    /**
+    * Suriname
+    */
+    Sr: 'SR',
+    /**
+    * Svalbard and Jan Mayen
+    */
+    Sj: 'SJ',
+    /**
+    * Sweden
+    */
+    Se: 'SE',
+    /**
+    * Switzerland
+    */
+    Ch: 'CH',
+    /**
+    * Syria
+    */
+    Sy: 'SY',
+    /**
+    * Taiwan
+    */
+    Tw: 'TW',
+    /**
+    * Tajikistan
+    */
+    Tj: 'TJ',
+    /**
+    * Tanzania
+    */
+    Tz: 'TZ',
+    /**
+    * Thailand
+    */
+    Th: 'TH',
+    /**
+    * Timor-Leste
+    */
+    Tl: 'TL',
+    /**
+    * Togo
+    */
+    Tg: 'TG',
+    /**
+    * Tokelau
+    */
+    Tk: 'TK',
+    /**
+    * Tonga
+    */
+    To: 'TO',
+    /**
+    * Trinidad and Tobago
+    */
+    Tt: 'TT',
+    /**
+    * Tunisia
+    */
+    Tn: 'TN',
+    /**
+    * Türkiye
+    */
+    Tr: 'TR',
+    /**
+    * Turkmenistan
+    */
+    Tm: 'TM',
+    /**
+    * Turks and Caicos Islands
+    */
+    Tc: 'TC',
+    /**
+    * Tuvalu
+    */
+    Tv: 'TV',
+    /**
+    * Uganda
+    */
+    Ug: 'UG',
+    /**
+    * Ukraine
+    */
+    Ua: 'UA',
+    /**
+    * United Arab Emirates
+    */
+    Ae: 'AE',
+    /**
+    * United Kingdom
+    */
+    Gb: 'GB',
+    /**
+    * United States Minor Outlying Islands
+    */
+    Um: 'UM',
+    /**
+    * United States of America
+    */
+    Us: 'US',
+    /**
+    * Uruguay
+    */
+    Uy: 'UY',
+    /**
+    * Uzbekistan
+    */
+    Uz: 'UZ',
+    /**
+    * Vanuatu
+    */
+    Vu: 'VU',
+    /**
+    * Venezuela
+    */
+    Ve: 'VE',
+    /**
+    * Vietnam
+    */
+    Vn: 'VN',
+    /**
+    * Virgin Islands (British)
+    */
+    Vg: 'VG',
+    /**
+    * Virgin Islands (U.S.)
+    */
+    Vi: 'VI',
+    /**
+    * Wallis and Futuna
+    */
+    Wf: 'WF',
+    /**
+    * Western Sahara
+    */
+    Eh: 'EH',
+    /**
+    * Yemen
+    */
+    Ye: 'YE',
+    /**
+    * Zambia
+    */
+    Zm: 'ZM',
+    /**
+    * Zimbabwe
+    */
+    Zw: 'ZW'
+} as const;
+
+export type CountryCodeEnum = typeof CountryCodeEnum[keyof typeof CountryCodeEnum];
+
+
+/**
+ * Really basic serializer for the payload that we need to send to CyberSource.
+ * @export
+ * @interface CyberSourceCheckout
+ */
+export interface CyberSourceCheckout {
+    /**
+     *
+     * @type {{ [key: string]: any; }}
+     * @memberof CyberSourceCheckout
+     */
+    'payload': { [key: string]: any; };
+    /**
+     *
+     * @type {string}
+     * @memberof CyberSourceCheckout
+     */
+    'url': string;
+    /**
+     *
+     * @type {string}
+     * @memberof CyberSourceCheckout
+     */
+    'method': string;
 }
 /**
  * Serializer for discounts.
@@ -195,6 +1498,36 @@ export interface Discount {
      */
     'company': Company;
 }
+
+
+/**
+ * * `percent-off` - percent-off * `dollars-off` - dollars-off * `fixed-price` - fixed-price
+ * @export
+ * @enum {string}
+ */
+
+export const DiscountTypeEnumDescriptions = {
+    'percent-off': "percent-off",
+    'dollars-off': "dollars-off",
+    'fixed-price': "fixed-price",
+} as const;
+
+export const DiscountTypeEnum = {
+    /**
+    * percent-off
+    */
+    PercentOff: 'percent-off',
+    /**
+    * dollars-off
+    */
+    DollarsOff: 'dollars-off',
+    /**
+    * fixed-price
+    */
+    FixedPrice: 'fixed-price'
+} as const;
+
+export type DiscountTypeEnum = typeof DiscountTypeEnum[keyof typeof DiscountTypeEnum];
 
 
 /**
@@ -716,6 +2049,45 @@ export interface ProductRequest {
     'price': string;
 }
 /**
+ * Simpler serializer for discounts.
+ * @export
+ * @interface SimpleDiscount
+ */
+export interface SimpleDiscount {
+    /**
+     *
+     * @type {number}
+     * @memberof SimpleDiscount
+     */
+    'id': number;
+    /**
+     *
+     * @type {string}
+     * @memberof SimpleDiscount
+     */
+    'discount_code': string;
+    /**
+     *
+     * @type {string}
+     * @memberof SimpleDiscount
+     */
+    'amount': string;
+    /**
+     *
+     * @type {DiscountTypeEnum}
+     * @memberof SimpleDiscount
+     */
+    'discount_type': DiscountTypeEnum;
+    /**
+     * Return the formatted discount amount.  This quantizes percent discounts to whole numbers. This is probably fine.
+     * @type {string}
+     * @memberof SimpleDiscount
+     */
+    'formatted_discount_amount': string;
+}
+
+
+/**
  * * `pending` - Pending * `fulfilled` - Fulfilled * `canceled` - Canceled * `refunded` - Refunded * `declined` - Declined * `errored` - Errored * `review` - Review
  * @export
  * @enum {string}
@@ -763,6 +2135,39 @@ export const StateEnum = {
 } as const;
 
 export type StateEnum = typeof StateEnum[keyof typeof StateEnum];
+
+
+/**
+ * TaxRate model serializer
+ * @export
+ * @interface TaxRate
+ */
+export interface TaxRate {
+    /**
+     *
+     * @type {number}
+     * @memberof TaxRate
+     */
+    'id': number;
+    /**
+     *
+     * @type {CountryCodeEnum}
+     * @memberof TaxRate
+     */
+    'country_code': CountryCodeEnum;
+    /**
+     *
+     * @type {string}
+     * @memberof TaxRate
+     */
+    'tax_rate'?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof TaxRate
+     */
+    'tax_rate_name'?: string;
+}
 
 
 /**
@@ -1908,11 +3313,14 @@ export const PaymentsApiAxiosParamCreator = function (configuration?: Configurat
     return {
         /**
          * Creates or updates a basket for the current user, adding the discount if valid.
+         * @param {string} discount_code
          * @param {string} system_slug
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        paymentsBasketsAddDiscountCreate: async (system_slug: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        paymentsBasketsAddDiscountCreate: async (discount_code: string, system_slug: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'discount_code' is not null or undefined
+            assertParamExists('paymentsBasketsAddDiscountCreate', 'discount_code', discount_code)
             // verify required parameter 'system_slug' is not null or undefined
             assertParamExists('paymentsBasketsAddDiscountCreate', 'system_slug', system_slug)
             const localVarPath = `/api/v0/payments/baskets/add_discount/{system_slug}/`
@@ -1927,6 +3335,10 @@ export const PaymentsApiAxiosParamCreator = function (configuration?: Configurat
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
+
+            if (discount_code !== undefined) {
+                localVarQueryParameter['discount_code'] = discount_code;
+            }
 
 
 
@@ -2120,6 +3532,39 @@ export const PaymentsApiAxiosParamCreator = function (configuration?: Configurat
             };
         },
         /**
+         * Generates and returns the form payload for the current basket for the specified system, which can be used to start the checkout process.
+         * @param {string} system_slug
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        paymentsCheckoutStartCheckoutCreate: async (system_slug: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'system_slug' is not null or undefined
+            assertParamExists('paymentsCheckoutStartCheckoutCreate', 'system_slug', system_slug)
+            const localVarPath = `/api/v0/payments/checkout/start_checkout/`
+                .replace(`{${"system_slug"}}`, encodeURIComponent(String(system_slug)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Create a discount.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2232,12 +3677,13 @@ export const PaymentsApiFp = function(configuration?: Configuration) {
     return {
         /**
          * Creates or updates a basket for the current user, adding the discount if valid.
+         * @param {string} discount_code
          * @param {string} system_slug
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async paymentsBasketsAddDiscountCreate(system_slug: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<BasketWithProduct>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.paymentsBasketsAddDiscountCreate(system_slug, options);
+        async paymentsBasketsAddDiscountCreate(discount_code: string, system_slug: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<BasketWithProduct>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.paymentsBasketsAddDiscountCreate(discount_code, system_slug, options);
             const index = configuration?.serverIndex ?? 0;
             const operationBasePath = operationServerMap['PaymentsApi.paymentsBasketsAddDiscountCreate']?.[index]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
@@ -2306,6 +3752,18 @@ export const PaymentsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
         },
         /**
+         * Generates and returns the form payload for the current basket for the specified system, which can be used to start the checkout process.
+         * @param {string} system_slug
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async paymentsCheckoutStartCheckoutCreate(system_slug: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CyberSourceCheckout>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.paymentsCheckoutStartCheckoutCreate(system_slug, options);
+            const index = configuration?.serverIndex ?? 0;
+            const operationBasePath = operationServerMap['PaymentsApi.paymentsCheckoutStartCheckoutCreate']?.[index]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, operationBasePath || basePath);
+        },
+        /**
          * Create a discount.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2358,7 +3816,7 @@ export const PaymentsApiFactory = function (configuration?: Configuration, baseP
          * @throws {RequiredError}
          */
         paymentsBasketsAddDiscountCreate(requestParameters: PaymentsApiPaymentsBasketsAddDiscountCreateRequest, options?: RawAxiosRequestConfig): AxiosPromise<BasketWithProduct> {
-            return localVarFp.paymentsBasketsAddDiscountCreate(requestParameters.system_slug, options).then((request) => request(axios, basePath));
+            return localVarFp.paymentsBasketsAddDiscountCreate(requestParameters.discount_code, requestParameters.system_slug, options).then((request) => request(axios, basePath));
         },
         /**
          * Clears the basket for the current user.
@@ -2406,6 +3864,15 @@ export const PaymentsApiFactory = function (configuration?: Configuration, baseP
             return localVarFp.paymentsBasketsRetrieve(requestParameters.id, options).then((request) => request(axios, basePath));
         },
         /**
+         * Generates and returns the form payload for the current basket for the specified system, which can be used to start the checkout process.
+         * @param {PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        paymentsCheckoutStartCheckoutCreate(requestParameters: PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest, options?: RawAxiosRequestConfig): AxiosPromise<CyberSourceCheckout> {
+            return localVarFp.paymentsCheckoutStartCheckoutCreate(requestParameters.system_slug, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Create a discount.
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -2440,6 +3907,13 @@ export const PaymentsApiFactory = function (configuration?: Configuration, baseP
  * @interface PaymentsApiPaymentsBasketsAddDiscountCreateRequest
  */
 export interface PaymentsApiPaymentsBasketsAddDiscountCreateRequest {
+    /**
+     *
+     * @type {string}
+     * @memberof PaymentsApiPaymentsBasketsAddDiscountCreate
+     */
+    readonly discount_code: string
+
     /**
      *
      * @type {string}
@@ -2540,6 +4014,20 @@ export interface PaymentsApiPaymentsBasketsRetrieveRequest {
 }
 
 /**
+ * Request parameters for paymentsCheckoutStartCheckoutCreate operation in PaymentsApi.
+ * @export
+ * @interface PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest
+ */
+export interface PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest {
+    /**
+     *
+     * @type {string}
+     * @memberof PaymentsApiPaymentsCheckoutStartCheckoutCreate
+     */
+    readonly system_slug: string
+}
+
+/**
  * Request parameters for paymentsOrdersHistoryList operation in PaymentsApi.
  * @export
  * @interface PaymentsApiPaymentsOrdersHistoryListRequest
@@ -2589,7 +4077,7 @@ export class PaymentsApi extends BaseAPI {
      * @memberof PaymentsApi
      */
     public paymentsBasketsAddDiscountCreate(requestParameters: PaymentsApiPaymentsBasketsAddDiscountCreateRequest, options?: RawAxiosRequestConfig) {
-        return PaymentsApiFp(this.configuration).paymentsBasketsAddDiscountCreate(requestParameters.system_slug, options).then((request) => request(this.axios, this.basePath));
+        return PaymentsApiFp(this.configuration).paymentsBasketsAddDiscountCreate(requestParameters.discount_code, requestParameters.system_slug, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -2645,6 +4133,17 @@ export class PaymentsApi extends BaseAPI {
      */
     public paymentsBasketsRetrieve(requestParameters: PaymentsApiPaymentsBasketsRetrieveRequest, options?: RawAxiosRequestConfig) {
         return PaymentsApiFp(this.configuration).paymentsBasketsRetrieve(requestParameters.id, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Generates and returns the form payload for the current basket for the specified system, which can be used to start the checkout process.
+     * @param {PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof PaymentsApi
+     */
+    public paymentsCheckoutStartCheckoutCreate(requestParameters: PaymentsApiPaymentsCheckoutStartCheckoutCreateRequest, options?: RawAxiosRequestConfig) {
+        return PaymentsApiFp(this.configuration).paymentsCheckoutStartCheckoutCreate(requestParameters.system_slug, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -437,9 +437,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
-  /api/v0/payments/checkout/start_checkout/:
+  /api/v0/payments/checkout/{system_slug}/:
     post:
-      operationId: payments_checkout_start_checkout_create
+      operationId: payments_checkout_create
       description: Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -359,6 +359,11 @@ paths:
       description: Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
+      - in: query
+        name: discount_code
+        schema:
+          type: string
+        required: true
       - in: path
         name: system_slug
         schema:
@@ -431,6 +436,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
+  /api/v0/payments/checkout/start_checkout/:
+    post:
+      operationId: payments_checkout_start_checkout_create
+      description: Generates and returns the form payload for the current basket for
+        the specified system, which can be used to start the checkout process.
+      parameters:
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - payments
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CyberSourceCheckout'
           description: ''
   /api/v0/payments/discounts/:
     post:
@@ -530,7 +555,16 @@ components:
             Returns:
                 Decimal: The price of the basket item reduced by an applicable discount.
           readOnly: true
+        quantity:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        discount_applied:
+          allOf:
+          - $ref: '#/components/schemas/SimpleDiscount'
+          readOnly: true
       required:
+      - discount_applied
       - discounted_price
       - id
       - price
@@ -560,6 +594,8 @@ components:
           format: double
           description: Get the tax for the basket
           readOnly: true
+        tax_rate:
+          $ref: '#/components/schemas/TaxRate'
         total_price:
           type: number
           format: double
@@ -571,6 +607,7 @@ components:
       - integrated_system
       - subtotal
       - tax
+      - tax_rate
       - total_price
       - user
     Company:
@@ -586,6 +623,774 @@ components:
       required:
       - id
       - name
+    CountryCodeEnum:
+      enum:
+      - AF
+      - AX
+      - AL
+      - DZ
+      - AS
+      - AD
+      - AO
+      - AI
+      - AQ
+      - AG
+      - AR
+      - AM
+      - AW
+      - AU
+      - AT
+      - AZ
+      - BS
+      - BH
+      - BD
+      - BB
+      - BY
+      - BE
+      - BZ
+      - BJ
+      - BM
+      - BT
+      - BO
+      - BQ
+      - BA
+      - BW
+      - BV
+      - BR
+      - IO
+      - BN
+      - BG
+      - BF
+      - BI
+      - CV
+      - KH
+      - CM
+      - CA
+      - KY
+      - CF
+      - TD
+      - CL
+      - CN
+      - CX
+      - CC
+      - CO
+      - KM
+      - CG
+      - CD
+      - CK
+      - CR
+      - CI
+      - HR
+      - CU
+      - CW
+      - CY
+      - CZ
+      - DK
+      - DJ
+      - DM
+      - DO
+      - EC
+      - EG
+      - SV
+      - GQ
+      - ER
+      - EE
+      - SZ
+      - ET
+      - FK
+      - FO
+      - FJ
+      - FI
+      - FR
+      - GF
+      - PF
+      - TF
+      - GA
+      - GM
+      - GE
+      - DE
+      - GH
+      - GI
+      - GR
+      - GL
+      - GD
+      - GP
+      - GU
+      - GT
+      - GG
+      - GN
+      - GW
+      - GY
+      - HT
+      - HM
+      - VA
+      - HN
+      - HK
+      - HU
+      - IS
+      - IN
+      - ID
+      - IR
+      - IQ
+      - IE
+      - IM
+      - IL
+      - IT
+      - JM
+      - JP
+      - JE
+      - JO
+      - KZ
+      - KE
+      - KI
+      - KW
+      - KG
+      - LA
+      - LV
+      - LB
+      - LS
+      - LR
+      - LY
+      - LI
+      - LT
+      - LU
+      - MO
+      - MG
+      - MW
+      - MY
+      - MV
+      - ML
+      - MT
+      - MH
+      - MQ
+      - MR
+      - MU
+      - YT
+      - MX
+      - FM
+      - MD
+      - MC
+      - MN
+      - ME
+      - MS
+      - MA
+      - MZ
+      - MM
+      - NA
+      - NR
+      - NP
+      - NL
+      - NC
+      - NZ
+      - NI
+      - NE
+      - NG
+      - NU
+      - NF
+      - KP
+      - MK
+      - MP
+      - 'NO'
+      - OM
+      - PK
+      - PW
+      - PS
+      - PA
+      - PG
+      - PY
+      - PE
+      - PH
+      - PN
+      - PL
+      - PT
+      - PR
+      - QA
+      - RE
+      - RO
+      - RU
+      - RW
+      - BL
+      - SH
+      - KN
+      - LC
+      - MF
+      - PM
+      - VC
+      - WS
+      - SM
+      - ST
+      - SA
+      - SN
+      - RS
+      - SC
+      - SL
+      - SG
+      - SX
+      - SK
+      - SI
+      - SB
+      - SO
+      - ZA
+      - GS
+      - KR
+      - SS
+      - ES
+      - LK
+      - SD
+      - SR
+      - SJ
+      - SE
+      - CH
+      - SY
+      - TW
+      - TJ
+      - TZ
+      - TH
+      - TL
+      - TG
+      - TK
+      - TO
+      - TT
+      - TN
+      - TR
+      - TM
+      - TC
+      - TV
+      - UG
+      - UA
+      - AE
+      - GB
+      - UM
+      - US
+      - UY
+      - UZ
+      - VU
+      - VE
+      - VN
+      - VG
+      - VI
+      - WF
+      - EH
+      - YE
+      - ZM
+      - ZW
+      type: string
+      description: |-
+        * `AF` - Afghanistan
+        * `AX` - Åland Islands
+        * `AL` - Albania
+        * `DZ` - Algeria
+        * `AS` - American Samoa
+        * `AD` - Andorra
+        * `AO` - Angola
+        * `AI` - Anguilla
+        * `AQ` - Antarctica
+        * `AG` - Antigua and Barbuda
+        * `AR` - Argentina
+        * `AM` - Armenia
+        * `AW` - Aruba
+        * `AU` - Australia
+        * `AT` - Austria
+        * `AZ` - Azerbaijan
+        * `BS` - Bahamas
+        * `BH` - Bahrain
+        * `BD` - Bangladesh
+        * `BB` - Barbados
+        * `BY` - Belarus
+        * `BE` - Belgium
+        * `BZ` - Belize
+        * `BJ` - Benin
+        * `BM` - Bermuda
+        * `BT` - Bhutan
+        * `BO` - Bolivia
+        * `BQ` - Bonaire, Sint Eustatius and Saba
+        * `BA` - Bosnia and Herzegovina
+        * `BW` - Botswana
+        * `BV` - Bouvet Island
+        * `BR` - Brazil
+        * `IO` - British Indian Ocean Territory
+        * `BN` - Brunei
+        * `BG` - Bulgaria
+        * `BF` - Burkina Faso
+        * `BI` - Burundi
+        * `CV` - Cabo Verde
+        * `KH` - Cambodia
+        * `CM` - Cameroon
+        * `CA` - Canada
+        * `KY` - Cayman Islands
+        * `CF` - Central African Republic
+        * `TD` - Chad
+        * `CL` - Chile
+        * `CN` - China
+        * `CX` - Christmas Island
+        * `CC` - Cocos (Keeling) Islands
+        * `CO` - Colombia
+        * `KM` - Comoros
+        * `CG` - Congo
+        * `CD` - Congo (the Democratic Republic of the)
+        * `CK` - Cook Islands
+        * `CR` - Costa Rica
+        * `CI` - Côte d'Ivoire
+        * `HR` - Croatia
+        * `CU` - Cuba
+        * `CW` - Curaçao
+        * `CY` - Cyprus
+        * `CZ` - Czechia
+        * `DK` - Denmark
+        * `DJ` - Djibouti
+        * `DM` - Dominica
+        * `DO` - Dominican Republic
+        * `EC` - Ecuador
+        * `EG` - Egypt
+        * `SV` - El Salvador
+        * `GQ` - Equatorial Guinea
+        * `ER` - Eritrea
+        * `EE` - Estonia
+        * `SZ` - Eswatini
+        * `ET` - Ethiopia
+        * `FK` - Falkland Islands (Malvinas)
+        * `FO` - Faroe Islands
+        * `FJ` - Fiji
+        * `FI` - Finland
+        * `FR` - France
+        * `GF` - French Guiana
+        * `PF` - French Polynesia
+        * `TF` - French Southern Territories
+        * `GA` - Gabon
+        * `GM` - Gambia
+        * `GE` - Georgia
+        * `DE` - Germany
+        * `GH` - Ghana
+        * `GI` - Gibraltar
+        * `GR` - Greece
+        * `GL` - Greenland
+        * `GD` - Grenada
+        * `GP` - Guadeloupe
+        * `GU` - Guam
+        * `GT` - Guatemala
+        * `GG` - Guernsey
+        * `GN` - Guinea
+        * `GW` - Guinea-Bissau
+        * `GY` - Guyana
+        * `HT` - Haiti
+        * `HM` - Heard Island and McDonald Islands
+        * `VA` - Holy See
+        * `HN` - Honduras
+        * `HK` - Hong Kong
+        * `HU` - Hungary
+        * `IS` - Iceland
+        * `IN` - India
+        * `ID` - Indonesia
+        * `IR` - Iran
+        * `IQ` - Iraq
+        * `IE` - Ireland
+        * `IM` - Isle of Man
+        * `IL` - Israel
+        * `IT` - Italy
+        * `JM` - Jamaica
+        * `JP` - Japan
+        * `JE` - Jersey
+        * `JO` - Jordan
+        * `KZ` - Kazakhstan
+        * `KE` - Kenya
+        * `KI` - Kiribati
+        * `KW` - Kuwait
+        * `KG` - Kyrgyzstan
+        * `LA` - Laos
+        * `LV` - Latvia
+        * `LB` - Lebanon
+        * `LS` - Lesotho
+        * `LR` - Liberia
+        * `LY` - Libya
+        * `LI` - Liechtenstein
+        * `LT` - Lithuania
+        * `LU` - Luxembourg
+        * `MO` - Macao
+        * `MG` - Madagascar
+        * `MW` - Malawi
+        * `MY` - Malaysia
+        * `MV` - Maldives
+        * `ML` - Mali
+        * `MT` - Malta
+        * `MH` - Marshall Islands
+        * `MQ` - Martinique
+        * `MR` - Mauritania
+        * `MU` - Mauritius
+        * `YT` - Mayotte
+        * `MX` - Mexico
+        * `FM` - Micronesia
+        * `MD` - Moldova
+        * `MC` - Monaco
+        * `MN` - Mongolia
+        * `ME` - Montenegro
+        * `MS` - Montserrat
+        * `MA` - Morocco
+        * `MZ` - Mozambique
+        * `MM` - Myanmar
+        * `NA` - Namibia
+        * `NR` - Nauru
+        * `NP` - Nepal
+        * `NL` - Netherlands
+        * `NC` - New Caledonia
+        * `NZ` - New Zealand
+        * `NI` - Nicaragua
+        * `NE` - Niger
+        * `NG` - Nigeria
+        * `NU` - Niue
+        * `NF` - Norfolk Island
+        * `KP` - North Korea
+        * `MK` - North Macedonia
+        * `MP` - Northern Mariana Islands
+        * `NO` - Norway
+        * `OM` - Oman
+        * `PK` - Pakistan
+        * `PW` - Palau
+        * `PS` - Palestine, State of
+        * `PA` - Panama
+        * `PG` - Papua New Guinea
+        * `PY` - Paraguay
+        * `PE` - Peru
+        * `PH` - Philippines
+        * `PN` - Pitcairn
+        * `PL` - Poland
+        * `PT` - Portugal
+        * `PR` - Puerto Rico
+        * `QA` - Qatar
+        * `RE` - Réunion
+        * `RO` - Romania
+        * `RU` - Russia
+        * `RW` - Rwanda
+        * `BL` - Saint Barthélemy
+        * `SH` - Saint Helena, Ascension and Tristan da Cunha
+        * `KN` - Saint Kitts and Nevis
+        * `LC` - Saint Lucia
+        * `MF` - Saint Martin (French part)
+        * `PM` - Saint Pierre and Miquelon
+        * `VC` - Saint Vincent and the Grenadines
+        * `WS` - Samoa
+        * `SM` - San Marino
+        * `ST` - Sao Tome and Principe
+        * `SA` - Saudi Arabia
+        * `SN` - Senegal
+        * `RS` - Serbia
+        * `SC` - Seychelles
+        * `SL` - Sierra Leone
+        * `SG` - Singapore
+        * `SX` - Sint Maarten (Dutch part)
+        * `SK` - Slovakia
+        * `SI` - Slovenia
+        * `SB` - Solomon Islands
+        * `SO` - Somalia
+        * `ZA` - South Africa
+        * `GS` - South Georgia and the South Sandwich Islands
+        * `KR` - South Korea
+        * `SS` - South Sudan
+        * `ES` - Spain
+        * `LK` - Sri Lanka
+        * `SD` - Sudan
+        * `SR` - Suriname
+        * `SJ` - Svalbard and Jan Mayen
+        * `SE` - Sweden
+        * `CH` - Switzerland
+        * `SY` - Syria
+        * `TW` - Taiwan
+        * `TJ` - Tajikistan
+        * `TZ` - Tanzania
+        * `TH` - Thailand
+        * `TL` - Timor-Leste
+        * `TG` - Togo
+        * `TK` - Tokelau
+        * `TO` - Tonga
+        * `TT` - Trinidad and Tobago
+        * `TN` - Tunisia
+        * `TR` - Türkiye
+        * `TM` - Turkmenistan
+        * `TC` - Turks and Caicos Islands
+        * `TV` - Tuvalu
+        * `UG` - Uganda
+        * `UA` - Ukraine
+        * `AE` - United Arab Emirates
+        * `GB` - United Kingdom
+        * `UM` - United States Minor Outlying Islands
+        * `US` - United States of America
+        * `UY` - Uruguay
+        * `UZ` - Uzbekistan
+        * `VU` - Vanuatu
+        * `VE` - Venezuela
+        * `VN` - Vietnam
+        * `VG` - Virgin Islands (British)
+        * `VI` - Virgin Islands (U.S.)
+        * `WF` - Wallis and Futuna
+        * `EH` - Western Sahara
+        * `YE` - Yemen
+        * `ZM` - Zambia
+        * `ZW` - Zimbabwe
+      x-enum-descriptions:
+      - Afghanistan
+      - Åland Islands
+      - Albania
+      - Algeria
+      - American Samoa
+      - Andorra
+      - Angola
+      - Anguilla
+      - Antarctica
+      - Antigua and Barbuda
+      - Argentina
+      - Armenia
+      - Aruba
+      - Australia
+      - Austria
+      - Azerbaijan
+      - Bahamas
+      - Bahrain
+      - Bangladesh
+      - Barbados
+      - Belarus
+      - Belgium
+      - Belize
+      - Benin
+      - Bermuda
+      - Bhutan
+      - Bolivia
+      - Bonaire, Sint Eustatius and Saba
+      - Bosnia and Herzegovina
+      - Botswana
+      - Bouvet Island
+      - Brazil
+      - British Indian Ocean Territory
+      - Brunei
+      - Bulgaria
+      - Burkina Faso
+      - Burundi
+      - Cabo Verde
+      - Cambodia
+      - Cameroon
+      - Canada
+      - Cayman Islands
+      - Central African Republic
+      - Chad
+      - Chile
+      - China
+      - Christmas Island
+      - Cocos (Keeling) Islands
+      - Colombia
+      - Comoros
+      - Congo
+      - Congo (the Democratic Republic of the)
+      - Cook Islands
+      - Costa Rica
+      - Côte d'Ivoire
+      - Croatia
+      - Cuba
+      - Curaçao
+      - Cyprus
+      - Czechia
+      - Denmark
+      - Djibouti
+      - Dominica
+      - Dominican Republic
+      - Ecuador
+      - Egypt
+      - El Salvador
+      - Equatorial Guinea
+      - Eritrea
+      - Estonia
+      - Eswatini
+      - Ethiopia
+      - Falkland Islands (Malvinas)
+      - Faroe Islands
+      - Fiji
+      - Finland
+      - France
+      - French Guiana
+      - French Polynesia
+      - French Southern Territories
+      - Gabon
+      - Gambia
+      - Georgia
+      - Germany
+      - Ghana
+      - Gibraltar
+      - Greece
+      - Greenland
+      - Grenada
+      - Guadeloupe
+      - Guam
+      - Guatemala
+      - Guernsey
+      - Guinea
+      - Guinea-Bissau
+      - Guyana
+      - Haiti
+      - Heard Island and McDonald Islands
+      - Holy See
+      - Honduras
+      - Hong Kong
+      - Hungary
+      - Iceland
+      - India
+      - Indonesia
+      - Iran
+      - Iraq
+      - Ireland
+      - Isle of Man
+      - Israel
+      - Italy
+      - Jamaica
+      - Japan
+      - Jersey
+      - Jordan
+      - Kazakhstan
+      - Kenya
+      - Kiribati
+      - Kuwait
+      - Kyrgyzstan
+      - Laos
+      - Latvia
+      - Lebanon
+      - Lesotho
+      - Liberia
+      - Libya
+      - Liechtenstein
+      - Lithuania
+      - Luxembourg
+      - Macao
+      - Madagascar
+      - Malawi
+      - Malaysia
+      - Maldives
+      - Mali
+      - Malta
+      - Marshall Islands
+      - Martinique
+      - Mauritania
+      - Mauritius
+      - Mayotte
+      - Mexico
+      - Micronesia
+      - Moldova
+      - Monaco
+      - Mongolia
+      - Montenegro
+      - Montserrat
+      - Morocco
+      - Mozambique
+      - Myanmar
+      - Namibia
+      - Nauru
+      - Nepal
+      - Netherlands
+      - New Caledonia
+      - New Zealand
+      - Nicaragua
+      - Niger
+      - Nigeria
+      - Niue
+      - Norfolk Island
+      - North Korea
+      - North Macedonia
+      - Northern Mariana Islands
+      - Norway
+      - Oman
+      - Pakistan
+      - Palau
+      - Palestine, State of
+      - Panama
+      - Papua New Guinea
+      - Paraguay
+      - Peru
+      - Philippines
+      - Pitcairn
+      - Poland
+      - Portugal
+      - Puerto Rico
+      - Qatar
+      - Réunion
+      - Romania
+      - Russia
+      - Rwanda
+      - Saint Barthélemy
+      - Saint Helena, Ascension and Tristan da Cunha
+      - Saint Kitts and Nevis
+      - Saint Lucia
+      - Saint Martin (French part)
+      - Saint Pierre and Miquelon
+      - Saint Vincent and the Grenadines
+      - Samoa
+      - San Marino
+      - Sao Tome and Principe
+      - Saudi Arabia
+      - Senegal
+      - Serbia
+      - Seychelles
+      - Sierra Leone
+      - Singapore
+      - Sint Maarten (Dutch part)
+      - Slovakia
+      - Slovenia
+      - Solomon Islands
+      - Somalia
+      - South Africa
+      - South Georgia and the South Sandwich Islands
+      - South Korea
+      - South Sudan
+      - Spain
+      - Sri Lanka
+      - Sudan
+      - Suriname
+      - Svalbard and Jan Mayen
+      - Sweden
+      - Switzerland
+      - Syria
+      - Taiwan
+      - Tajikistan
+      - Tanzania
+      - Thailand
+      - Timor-Leste
+      - Togo
+      - Tokelau
+      - Tonga
+      - Trinidad and Tobago
+      - Tunisia
+      - Türkiye
+      - Turkmenistan
+      - Turks and Caicos Islands
+      - Tuvalu
+      - Uganda
+      - Ukraine
+      - United Arab Emirates
+      - United Kingdom
+      - United States Minor Outlying Islands
+      - United States of America
+      - Uruguay
+      - Uzbekistan
+      - Vanuatu
+      - Venezuela
+      - Vietnam
+      - Virgin Islands (British)
+      - Virgin Islands (U.S.)
+      - Wallis and Futuna
+      - Western Sahara
+      - Yemen
+      - Zambia
+      - Zimbabwe
+    CyberSourceCheckout:
+      type: object
+      description: Really basic serializer for the payload that we need to send to
+        CyberSource.
+      properties:
+        payload:
+          type: object
+          additionalProperties: {}
+        url:
+          type: string
+        method:
+          type: string
+      required:
+      - method
+      - payload
+      - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -640,6 +1445,20 @@ components:
       - id
       - integrated_system
       - product
+    DiscountTypeEnum:
+      enum:
+      - percent-off
+      - dollars-off
+      - fixed-price
+      type: string
+      description: |-
+        * `percent-off` - percent-off
+        * `dollars-off` - dollars-off
+        * `fixed-price` - fixed-price
+      x-enum-descriptions:
+      - percent-off
+      - dollars-off
+      - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -986,6 +1805,35 @@ components:
       - price
       - sku
       - system
+    SimpleDiscount:
+      type: object
+      description: Simpler serializer for discounts.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        discount_code:
+          type: string
+          maxLength: 100
+        amount:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
+        discount_type:
+          $ref: '#/components/schemas/DiscountTypeEnum'
+        formatted_discount_amount:
+          type: string
+          description: |-
+            Return the formatted discount amount.
+
+            This quantizes percent discounts to whole numbers. This is probably fine.
+          readOnly: true
+      required:
+      - amount
+      - discount_code
+      - discount_type
+      - formatted_discount_amount
+      - id
     StateEnum:
       enum:
       - pending
@@ -1012,6 +1860,25 @@ components:
       - Declined
       - Errored
       - Review
+    TaxRate:
+      type: object
+      description: TaxRate model serializer
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        country_code:
+          $ref: '#/components/schemas/CountryCodeEnum'
+        tax_rate:
+          type: string
+          format: decimal
+          pattern: ^-?\d{0,2}(?:\.\d{0,4})?$
+        tax_rate_name:
+          type: string
+          maxLength: 100
+      required:
+      - country_code
+      - id
     User:
       type: object
       description: Serializer for User model.

--- a/payments/models.py
+++ b/payments/models.py
@@ -25,6 +25,8 @@ from payments.constants import GEOLOCATION_CHOICES, GEOLOCATION_TYPE_NONE
 from payments.utils import product_price_with_discount
 from system_meta.models import IntegratedSystem, Product
 from unified_ecommerce.constants import (
+    DISCOUNT_TYPE_DOLLARS_OFF,
+    DISCOUNT_TYPE_PERCENT_OFF,
     DISCOUNT_TYPES,
     PAYMENT_TYPES,
     POST_SALE_SOURCE_REDIRECT,
@@ -255,6 +257,21 @@ class Discount(TimestampedModel):
                 )
         exception_message = "Invalid product version specified"
         raise TypeError(exception_message)
+
+    @cached_property
+    def formatted_discount_amount(self) -> str:
+        """
+        Return the formatted discount amount.
+
+        This quantizes percent discounts to whole numbers. This is probably fine.
+        """
+
+        if self.discount_type == DISCOUNT_TYPE_PERCENT_OFF:
+            return f"{Decimal(self.amount).quantize(Decimal('0'))}%"
+        elif self.discount_type == DISCOUNT_TYPE_DOLLARS_OFF:
+            return f"${Decimal(self.amount).quantize(Decimal('0.01'))}"
+
+        return f"${Decimal(self.amount).quantize(Decimal('0.01'))}"
 
     class Meta:
         """Model meta options."""

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -19,14 +19,11 @@ from drf_spectacular.utils import (
 )
 from mitol.payment_gateway.api import PaymentGateway
 from rest_framework import status
-from rest_framework.decorators import action, api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.viewsets import (
-    ReadOnlyModelViewSet,
-    ViewSet,
-)
+from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from payments import api
 from payments.exceptions import ProductBlockedError
@@ -225,9 +222,24 @@ def clear_basket(request, system_slug: str):
 # Checkout
 
 
-class CheckoutApiViewSet(ViewSet):
+@extend_schema(
+    description=(
+        "Generates and returns the form payload for the current basket for"
+        " the specified system, which can be used to start the checkout process."
+    ),
+    methods=["POST"],
+    versions=["v0"],
+    request=None,
+    parameters=[
+        OpenApiParameter("system_slug", OpenApiTypes.STR, OpenApiParameter.PATH),
+    ],
+    responses=CyberSourceCheckoutSerializer,
+)
+@api_view(["POST"])
+@permission_classes((IsAuthenticated,))
+def start_checkout(request, system_slug: str):
     """
-    Handles checkout.
+    Handle checkout.
 
     Because of the way the payload works for CyberSource, we don't really have
     a dataclass for this. (It involves fields that have variable names - the
@@ -241,54 +253,22 @@ class CheckoutApiViewSet(ViewSet):
     The payload def can be found in the ol-django payment gateway app or in the
     CyberSource documentation.
     """
+    try:
+        system = IntegratedSystem.objects.get(slug=system_slug)
+        payload = api.generate_checkout_payload(request, system)
+    except ObjectDoesNotExist:
+        return Response("No basket", status=status.HTTP_406_NOT_ACCEPTABLE)
 
-    permission_classes = (IsAuthenticated,)
+    if (
+        "country_blocked" in payload
+        or "no_checkout" in payload
+        or "purchased_same_courserun" in payload
+        or "purchased_non_upgradeable_courserun" in payload
+        or "invalid_discounts" in payload
+    ):
+        return Response(payload["response"], status=status.HTTP_406_NOT_ACCEPTABLE)
 
-    @extend_schema(
-        description=(
-            "Generates and returns the form payload for the current basket for"
-            " the specified system, which can be used to start the checkout process."
-        ),
-        methods=["POST"],
-        request=None,
-        parameters=[
-            OpenApiParameter("system_slug", OpenApiTypes.STR, OpenApiParameter.PATH),
-        ],
-        responses=CyberSourceCheckoutSerializer,
-    )
-    @action(
-        detail=False, methods=["post"], name="Start Checkout", url_name="start_checkout"
-    )
-    def start_checkout(self, request):
-        """
-        Start the checkout process. This assembles the basket items
-        into an Order with Lines for each item, applies the attached basket
-        discounts, and then calls the payment gateway to prepare for payment.
-
-        This is expected to be called from within the Ecommerce cart app, not
-        from an integrated system.
-
-        Returns:
-            - JSON payload from the ol-django payment gateway app. The payment
-              gateway returns data necessary to construct a form that will
-              ultimately POST to the actual payment processor.
-        """
-        try:
-            system = IntegratedSystem.objects.get(slug=self.kwargs["system_slug"])
-            payload = api.generate_checkout_payload(request, system)
-        except ObjectDoesNotExist:
-            return Response("No basket", status=status.HTTP_406_NOT_ACCEPTABLE)
-
-        if (
-            "country_blocked" in payload
-            or "no_checkout" in payload
-            or "purchased_same_courserun" in payload
-            or "purchased_non_upgradeable_courserun" in payload
-            or "invalid_discounts" in payload
-        ):
-            return Response(payload["response"], status=status.HTTP_406_NOT_ACCEPTABLE)
-
-        return Response(CyberSourceCheckoutSerializer(payload).data)
+    return Response(CyberSourceCheckoutSerializer(payload).data)
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/payments/views/v0/urls.py
+++ b/payments/views/v0/urls.py
@@ -5,7 +5,6 @@ from django.urls import include, path, re_path
 from payments.views.v0 import (
     BackofficeCallbackView,
     BasketViewSet,
-    CheckoutApiViewSet,
     CheckoutCallbackView,
     DiscountAPIViewSet,
     OrderHistoryViewSet,
@@ -13,6 +12,7 @@ from payments.views.v0 import (
     clear_basket,
     create_basket_from_product,
     get_user_basket_for_system,
+    start_checkout,
 )
 from unified_ecommerce.routers import SimpleRouterWithNesting
 
@@ -21,8 +21,6 @@ router = SimpleRouterWithNesting()
 basket_router = router.register(r"baskets", BasketViewSet, basename="basket")
 
 router.register(r"orders/history", OrderHistoryViewSet, basename="orderhistory_api")
-
-router.register(r"checkout", CheckoutApiViewSet, basename="checkout")
 
 urlpatterns = [
     path(
@@ -49,6 +47,11 @@ urlpatterns = [
         "checkout/callback/",
         BackofficeCallbackView.as_view(),
         name="checkout-callback",
+    ),
+    path(
+        "checkout/<str:system_slug>/",
+        start_checkout,
+        name="start_checkout",
     ),
     path(
         "discounts/",

--- a/unified_ecommerce/settings.py
+++ b/unified_ecommerce/settings.py
@@ -124,6 +124,8 @@ CORS_ALLOWED_ORIGINS = get_list_of_str("CORS_ALLOWED_ORIGINS", [])
 CORS_ALLOWED_ORIGIN_REGEXES = get_list_of_str("CORS_ALLOWED_ORIGIN_REGEXES", [])
 CORS_ALLOW_CREDENTIALS = True
 
+CSRF_TRUSTED_ORIGINS = get_list_of_str("CSRF_TRUSTED_ORIGINS", [])
+
 # enable the nplusone profiler only in debug mode
 if DEBUG:
     INSTALLED_APPS += ("nplusone.ext.django",)


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5656

### Description (What does it do?)

Changes some stuff to make things work better for the frontend code:
- Expose the CSRF settings so we can set them
- Fixes the API spec for the add discount API to add in the discount code parameter (wasn't there before)
- Exposes the `start_checkout` API to the OpenAPI spec
- Include discount information with basket items
- Reworks the `start_checkout` API to be a view function so it's easier to route and generate docs for
- Regenerate the OpenAPI specs/clients

### How can this be tested?

Tests should pass. You should see the start checkout API in Swagger, you should be able to see the discount code property the add discount API, and baskets should include discount information if there is any for the items within.

This branch is necessary to make [this PR in the frontend repo](https://github.com/mitodl/unified-ecommerce-frontend/pull/10) work, so you can test by checking that out and then using the frontend.
