### PR TITLE
Fix country code assignment on checkout

### DIFF
--- a/payments/models.py
+++ b/payments/models.py
@@ -919,11 +919,19 @@ class PendingOrder(Order):
             # (this re-uses a PendingOrder if it exists, so it might now be wrong)
             order.tax_rate = basket.tax_rate
             order.purchaser_ip = basket.user_ip
-            order.purchaser_taxable_country_code = basket.user_taxable_country_code
+            order.purchaser_taxable_country_code = (
+                basket.user_taxable_country_code
+                if basket.user_taxable_country_code
+                else ""
+            )
             order.purchaser_taxable_geolocation_type = (
                 basket.user_taxable_geolocation_type
             )
-            order.purchaser_blockable_country_code = basket.user_blockable_country_code
+            order.purchaser_blockable_country_code = (
+                basket.user_blockable_country_code
+                if basket.user_blockable_country_code
+                else ""
+            )
             order.purchaser_blockable_geolocation_type = (
                 basket.user_blockable_geolocation_type
             )

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -8,7 +8,6 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
-from django.views.generic import View
 from django_filters import rest_framework as filters
 from drf_spectacular.utils import (
     OpenApiParameter,
@@ -20,7 +19,7 @@ from drf_spectacular.utils import (
 from mitol.payment_gateway.api import PaymentGateway
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -272,13 +271,16 @@ def start_checkout(request, system_slug: str):
 
 
 @method_decorator(csrf_exempt, name="dispatch")
-class CheckoutCallbackView(View):
+class CheckoutCallbackView(APIView):
     """
     Handles the redirect from the payment gateway after the user has completed
     checkout. This may not always happen as the redirect back to the app
     occasionally fails. If it does, then the payment gateway should trigger
     things via the backoffice webhook.
     """
+
+    authentication_classes = []  # disables authentication
+    permission_classes = (AllowAny,)  # disables permission
 
     def _get_payment_process_redirect_url_from_line_items(self, request):
         """

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -280,7 +280,7 @@ class CheckoutCallbackView(APIView):
     """
 
     authentication_classes = []  # disables authentication
-    permission_classes = (AllowAny,)  # disables permission
+    permission_classes = [AllowAny]  # disables permission
 
     def _get_payment_process_redirect_url_from_line_items(self, request):
         """

--- a/payments/views/v0/urls.py
+++ b/payments/views/v0/urls.py
@@ -49,6 +49,11 @@ urlpatterns = [
         name="checkout-callback",
     ),
     path(
+        "checkout/result/",
+        CheckoutCallbackView.as_view(),
+        name="checkout-result-callback",
+    ),
+    path(
         "checkout/<str:system_slug>/",
         start_checkout,
         name="start_checkout",
@@ -63,10 +68,5 @@ urlpatterns = [
         include(
             router.urls,
         ),
-    ),
-    path(
-        "checkout/result/",
-        CheckoutCallbackView.as_view(),
-        name="checkout-result-callback",
     ),
 ]

--- a/system_meta/management/commands/generate_test_data.py
+++ b/system_meta/management/commands/generate_test_data.py
@@ -16,6 +16,7 @@ import reversion
 from django.core.management import BaseCommand
 from django.core.management.base import CommandParser
 from django.db import transaction
+from django.urls import reverse
 
 from system_meta.models import IntegratedSystem, Product
 
@@ -111,6 +112,11 @@ class Command(BaseCommand):
                 description=f"Test System {i} description.",
                 api_key=uuid.uuid4(),
             )
+            system.payment_process_redirect_url = reverse(
+                "cart", kwargs={"system_slug": system.slug}
+            )
+            system.save()
+
             self.stdout.write(f"Created system {system.name} - {system.slug}")
 
     def add_test_products(self, system_slug: str) -> None:


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl#hq/6302

### Description (What does it do?)

When the user goes to check out, the basket gets converted into an order. The user's country code information is copied as part of this. These codes _can_ be blank but they can't be null.

If the user doesn't have a country code in the basket, the conversion code will copy a None into the Order model, which results in an error. This fixes that - instead it will copy a blank string. This is an edge case, since in production you'll either have a country code via profile or via geolocation most likely, but locally it is more of an issue.

Additionally, this fixes a couple of small issues that popped up during testing of the code:
- The `generate_test_data` command now sets a reasonable redirect URL (back to the system's cart) for the integrated system. The user is sent to this URL after checkout and, as it was, you'd end up redirecting back _into_ the checkout callback API, which would generate an error. Now it should go back to the cart page. This won't affect system records that already exist.
- The routes have been rearranged slightly so that the user-facing checkout callback can be called without an active session.
- The user-facing checkout callback now subclasses `APIView` rather than `View` (so we can more easily adjust permissions, and since this will really be more of an API view anyway going forward).

### How can this be tested?

Ensure you have no `Net blocks` set up (`Geonames` are OK) and the account you're using does not have a country code set up in the profile. Then, add an item to the cart and attempt to checkout. You can either complete the process or cancel - either way it should work, and upon completion you should go back to the system without a 403 error. (You may get a Method Not Allowed - this is fine and means the integrated system's redirect URI isn't set right.) 

You should be able to run `generate_test_data` and it should generate integrated system records with reasonable `Payment process redirect url` settings.
