### PR TITLE
Add API to bulk-add SKUs to a basket, optionally with a discount

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -1417,6 +1417,56 @@ export type CountryCodeEnum =
   (typeof CountryCodeEnum)[keyof typeof CountryCodeEnum]
 
 /**
+ * Serializer for creating a basket with products. (For OpenAPI spec.)
+ * @export
+ * @interface CreateBasketWithProductsRequest
+ */
+export interface CreateBasketWithProductsRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof CreateBasketWithProductsRequest
+   */
+  system_slug: string
+  /**
+   *
+   * @type {Array<CreateBasketWithProductsSkuRequest>}
+   * @memberof CreateBasketWithProductsRequest
+   */
+  skus: Array<CreateBasketWithProductsSkuRequest>
+  /**
+   *
+   * @type {boolean}
+   * @memberof CreateBasketWithProductsRequest
+   */
+  checkout: boolean
+  /**
+   *
+   * @type {string}
+   * @memberof CreateBasketWithProductsRequest
+   */
+  discount_code: string
+}
+/**
+ * Defines the schema for a SKU in the CreateBasketWithProductsSerializer.
+ * @export
+ * @interface CreateBasketWithProductsSkuRequest
+ */
+export interface CreateBasketWithProductsSkuRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof CreateBasketWithProductsSkuRequest
+   */
+  sku: string
+  /**
+   *
+   * @type {number}
+   * @memberof CreateBasketWithProductsSkuRequest
+   */
+  quantity: number
+}
+/**
  * Really basic serializer for the payload that we need to send to CyberSource.
  * @export
  * @interface CyberSourceCheckout
@@ -4085,6 +4135,59 @@ export const PaymentsApiAxiosParamCreator = function (
       }
     },
     /**
+     * Creates or updates a basket for the current user, adding the selected product.
+     * @param {CreateBasketWithProductsRequest} CreateBasketWithProductsRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    paymentsBasketsCreateWithProductsCreate: async (
+      CreateBasketWithProductsRequest: CreateBasketWithProductsRequest,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'CreateBasketWithProductsRequest' is not null or undefined
+      assertParamExists(
+        "paymentsBasketsCreateWithProductsCreate",
+        "CreateBasketWithProductsRequest",
+        CreateBasketWithProductsRequest,
+      )
+      const localVarPath = `/api/v0/payments/baskets/create_with_products/`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "POST",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      localVarHeaderParameter["Content-Type"] = "application/json"
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        CreateBasketWithProductsRequest,
+        localVarRequestOptions,
+        configuration,
+      )
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
      * Returns or creates a basket for the current user and system.
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
@@ -4525,6 +4628,39 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
         )(axios, operationBasePath || basePath)
     },
     /**
+     * Creates or updates a basket for the current user, adding the selected product.
+     * @param {CreateBasketWithProductsRequest} CreateBasketWithProductsRequest
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async paymentsBasketsCreateWithProductsCreate(
+      CreateBasketWithProductsRequest: CreateBasketWithProductsRequest,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<BasketWithProduct>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.paymentsBasketsCreateWithProductsCreate(
+          CreateBasketWithProductsRequest,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap[
+          "PaymentsApi.paymentsBasketsCreateWithProductsCreate"
+        ]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
      * Returns or creates a basket for the current user and system.
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
@@ -4805,6 +4941,23 @@ export const PaymentsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
+     * Creates or updates a basket for the current user, adding the selected product.
+     * @param {PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    paymentsBasketsCreateWithProductsCreate(
+      requestParameters: PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<BasketWithProduct> {
+      return localVarFp
+        .paymentsBasketsCreateWithProductsCreate(
+          requestParameters.CreateBasketWithProductsRequest,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+    /**
      * Returns or creates a basket for the current user and system.
      * @param {PaymentsApiPaymentsBasketsForSystemRetrieveRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -4972,6 +5125,20 @@ export interface PaymentsApiPaymentsBasketsCreateFromProductCreateRequest {
 }
 
 /**
+ * Request parameters for paymentsBasketsCreateWithProductsCreate operation in PaymentsApi.
+ * @export
+ * @interface PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest
+ */
+export interface PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest {
+  /**
+   *
+   * @type {CreateBasketWithProductsRequest}
+   * @memberof PaymentsApiPaymentsBasketsCreateWithProductsCreate
+   */
+  readonly CreateBasketWithProductsRequest: CreateBasketWithProductsRequest
+}
+
+/**
  * Request parameters for paymentsBasketsForSystemRetrieve operation in PaymentsApi.
  * @export
  * @interface PaymentsApiPaymentsBasketsForSystemRetrieveRequest
@@ -5134,6 +5301,25 @@ export class PaymentsApi extends BaseAPI {
       .paymentsBasketsCreateFromProductCreate(
         requestParameters.sku,
         requestParameters.system_slug,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Creates or updates a basket for the current user, adding the selected product.
+   * @param {PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof PaymentsApi
+   */
+  public paymentsBasketsCreateWithProductsCreate(
+    requestParameters: PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return PaymentsApiFp(this.configuration)
+      .paymentsBasketsCreateWithProductsCreate(
+        requestParameters.CreateBasketWithProductsRequest,
         options,
       )
       .then((request) => request(this.axios, this.basePath))

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9,527 +9,557 @@ paths:
       operationId: meta_integrated_system_list
       description: Viewset for IntegratedSystem model.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedIntegratedSystemList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedIntegratedSystemList"
+          description: ""
     post:
       operationId: meta_integrated_system_create
       description: Viewset for IntegratedSystem model.
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
         required: true
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
   /api/v0/meta/integrated_system/{id}/:
     get:
       operationId: meta_integrated_system_retrieve
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     put:
       operationId: meta_integrated_system_update
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
         required: true
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     patch:
       operationId: meta_integrated_system_partial_update
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     delete:
       operationId: meta_integrated_system_destroy
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/meta/product/:
     get:
       operationId: meta_product_list
       description: Viewset for Product model.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: system__slug
-        schema:
-          type: string
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - in: query
+          name: name
+          schema:
+            type: string
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
+        - in: query
+          name: system__slug
+          schema:
+            type: string
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedProductList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedProductList"
+          description: ""
     post:
       operationId: meta_product_create
       description: Viewset for Product model.
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
         required: true
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
   /api/v0/meta/product/{id}/:
     get:
       operationId: meta_product_retrieve
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     put:
       operationId: meta_product_update
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
         required: true
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     patch:
       operationId: meta_product_partial_update
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     delete:
       operationId: meta_product_destroy
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/payments/baskets/:
     get:
       operationId: payments_baskets_list
       description: Retrives the current user's baskets, one per system.
       parameters:
-      - in: query
-        name: integrated_system
-        schema:
-          type: integer
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - in: query
+          name: integrated_system
+          schema:
+            type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedBasketWithProductList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedBasketWithProductList"
+          description: ""
   /api/v0/payments/baskets/{id}/:
     get:
       operationId: payments_baskets_retrieve
       description: Retrieve a basket for the current user.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/add_discount/{system_slug}/:
     post:
       operationId: payments_baskets_add_discount_create
-      description: Creates or updates a basket for the current user, adding the discount
+      description:
+        Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
-      - in: query
-        name: discount_code
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: query
+          name: discount_code
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/clear/{system_slug}/:
     delete:
       operationId: payments_baskets_clear_destroy
       description: Clears the basket for the current user.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/:
     post:
       operationId: payments_baskets_create_from_product_create
-      description: Creates or updates a basket for the current user, adding the selected
+      description:
+        Creates or updates a basket for the current user, adding the selected
         product.
       parameters:
-      - in: path
-        name: sku
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
+  /api/v0/payments/baskets/create_with_products/:
+    post:
+      operationId: payments_baskets_create_with_products_create
+      description:
+        Creates or updates a basket for the current user, adding the selected
+        product.
+      tags:
+        - payments
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/for_system/{system_slug}/:
     get:
       operationId: payments_baskets_for_system_retrieve
       description: Returns or creates a basket for the current user and system.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/checkout/{system_slug}/:
     post:
       operationId: payments_checkout_create
-      description: Generates and returns the form payload for the current basket for
+      description:
+        Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CyberSourceCheckout'
-          description: ''
+                $ref: "#/components/schemas/CyberSourceCheckout"
+          description: ""
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create
       description: Create a discount.
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Discount'
-          description: ''
+                $ref: "#/components/schemas/Discount"
+          description: ""
   /api/v0/payments/orders/history/:
     get:
       operationId: payments_orders_history_list
       description: Retrives the current user's completed orders.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedOrderHistoryList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedOrderHistoryList"
+          description: ""
   /api/v0/payments/orders/history/{id}/:
     get:
       operationId: payments_orders_history_retrieve
       description: Retrieve a completed order for the current user.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderHistory'
-          description: ''
+                $ref: "#/components/schemas/OrderHistory"
+          description: ""
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
       description: User retrieve and update viewsets for the current user
       tags:
-      - users
+        - users
       security:
-      - {}
+        - {}
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
-          description: ''
+                $ref: "#/components/schemas/User"
+          description: ""
 components:
   schemas:
     BasketItemWithProduct:
@@ -537,7 +567,7 @@ components:
       description: Basket item model serializer with product information
       properties:
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
         id:
           type: integer
           readOnly: true
@@ -561,14 +591,14 @@ components:
           minimum: 0
         discount_applied:
           allOf:
-          - $ref: '#/components/schemas/SimpleDiscount'
+            - $ref: "#/components/schemas/SimpleDiscount"
           readOnly: true
       required:
-      - discount_applied
-      - discounted_price
-      - id
-      - price
-      - product
+        - discount_applied
+        - discounted_price
+        - id
+        - price
+        - product
     BasketWithProduct:
       type: object
       description: Basket model serializer with items and products
@@ -579,11 +609,11 @@ components:
         user:
           type: integer
         integrated_system:
-          $ref: '#/components/schemas/IntegratedSystem'
+          $ref: "#/components/schemas/IntegratedSystem"
         basket_items:
           type: array
           items:
-            $ref: '#/components/schemas/BasketItemWithProduct'
+            $ref: "#/components/schemas/BasketItemWithProduct"
         subtotal:
           type: number
           format: double
@@ -595,21 +625,21 @@ components:
           description: Get the tax for the basket
           readOnly: true
         tax_rate:
-          $ref: '#/components/schemas/TaxRate'
+          $ref: "#/components/schemas/TaxRate"
         total_price:
           type: number
           format: double
           description: Get the total price for the basket
           readOnly: true
       required:
-      - basket_items
-      - id
-      - integrated_system
-      - subtotal
-      - tax
-      - tax_rate
-      - total_price
-      - user
+        - basket_items
+        - id
+        - integrated_system
+        - subtotal
+        - tax
+        - tax_rate
+        - total_price
+        - user
     Company:
       type: object
       description: Serializer for companies.
@@ -621,259 +651,259 @@ components:
           type: string
           maxLength: 255
       required:
-      - id
-      - name
+        - id
+        - name
     CountryCodeEnum:
       enum:
-      - AF
-      - AX
-      - AL
-      - DZ
-      - AS
-      - AD
-      - AO
-      - AI
-      - AQ
-      - AG
-      - AR
-      - AM
-      - AW
-      - AU
-      - AT
-      - AZ
-      - BS
-      - BH
-      - BD
-      - BB
-      - BY
-      - BE
-      - BZ
-      - BJ
-      - BM
-      - BT
-      - BO
-      - BQ
-      - BA
-      - BW
-      - BV
-      - BR
-      - IO
-      - BN
-      - BG
-      - BF
-      - BI
-      - CV
-      - KH
-      - CM
-      - CA
-      - KY
-      - CF
-      - TD
-      - CL
-      - CN
-      - CX
-      - CC
-      - CO
-      - KM
-      - CG
-      - CD
-      - CK
-      - CR
-      - CI
-      - HR
-      - CU
-      - CW
-      - CY
-      - CZ
-      - DK
-      - DJ
-      - DM
-      - DO
-      - EC
-      - EG
-      - SV
-      - GQ
-      - ER
-      - EE
-      - SZ
-      - ET
-      - FK
-      - FO
-      - FJ
-      - FI
-      - FR
-      - GF
-      - PF
-      - TF
-      - GA
-      - GM
-      - GE
-      - DE
-      - GH
-      - GI
-      - GR
-      - GL
-      - GD
-      - GP
-      - GU
-      - GT
-      - GG
-      - GN
-      - GW
-      - GY
-      - HT
-      - HM
-      - VA
-      - HN
-      - HK
-      - HU
-      - IS
-      - IN
-      - ID
-      - IR
-      - IQ
-      - IE
-      - IM
-      - IL
-      - IT
-      - JM
-      - JP
-      - JE
-      - JO
-      - KZ
-      - KE
-      - KI
-      - KW
-      - KG
-      - LA
-      - LV
-      - LB
-      - LS
-      - LR
-      - LY
-      - LI
-      - LT
-      - LU
-      - MO
-      - MG
-      - MW
-      - MY
-      - MV
-      - ML
-      - MT
-      - MH
-      - MQ
-      - MR
-      - MU
-      - YT
-      - MX
-      - FM
-      - MD
-      - MC
-      - MN
-      - ME
-      - MS
-      - MA
-      - MZ
-      - MM
-      - NA
-      - NR
-      - NP
-      - NL
-      - NC
-      - NZ
-      - NI
-      - NE
-      - NG
-      - NU
-      - NF
-      - KP
-      - MK
-      - MP
-      - 'NO'
-      - OM
-      - PK
-      - PW
-      - PS
-      - PA
-      - PG
-      - PY
-      - PE
-      - PH
-      - PN
-      - PL
-      - PT
-      - PR
-      - QA
-      - RE
-      - RO
-      - RU
-      - RW
-      - BL
-      - SH
-      - KN
-      - LC
-      - MF
-      - PM
-      - VC
-      - WS
-      - SM
-      - ST
-      - SA
-      - SN
-      - RS
-      - SC
-      - SL
-      - SG
-      - SX
-      - SK
-      - SI
-      - SB
-      - SO
-      - ZA
-      - GS
-      - KR
-      - SS
-      - ES
-      - LK
-      - SD
-      - SR
-      - SJ
-      - SE
-      - CH
-      - SY
-      - TW
-      - TJ
-      - TZ
-      - TH
-      - TL
-      - TG
-      - TK
-      - TO
-      - TT
-      - TN
-      - TR
-      - TM
-      - TC
-      - TV
-      - UG
-      - UA
-      - AE
-      - GB
-      - UM
-      - US
-      - UY
-      - UZ
-      - VU
-      - VE
-      - VN
-      - VG
-      - VI
-      - WF
-      - EH
-      - YE
-      - ZM
-      - ZW
+        - AF
+        - AX
+        - AL
+        - DZ
+        - AS
+        - AD
+        - AO
+        - AI
+        - AQ
+        - AG
+        - AR
+        - AM
+        - AW
+        - AU
+        - AT
+        - AZ
+        - BS
+        - BH
+        - BD
+        - BB
+        - BY
+        - BE
+        - BZ
+        - BJ
+        - BM
+        - BT
+        - BO
+        - BQ
+        - BA
+        - BW
+        - BV
+        - BR
+        - IO
+        - BN
+        - BG
+        - BF
+        - BI
+        - CV
+        - KH
+        - CM
+        - CA
+        - KY
+        - CF
+        - TD
+        - CL
+        - CN
+        - CX
+        - CC
+        - CO
+        - KM
+        - CG
+        - CD
+        - CK
+        - CR
+        - CI
+        - HR
+        - CU
+        - CW
+        - CY
+        - CZ
+        - DK
+        - DJ
+        - DM
+        - DO
+        - EC
+        - EG
+        - SV
+        - GQ
+        - ER
+        - EE
+        - SZ
+        - ET
+        - FK
+        - FO
+        - FJ
+        - FI
+        - FR
+        - GF
+        - PF
+        - TF
+        - GA
+        - GM
+        - GE
+        - DE
+        - GH
+        - GI
+        - GR
+        - GL
+        - GD
+        - GP
+        - GU
+        - GT
+        - GG
+        - GN
+        - GW
+        - GY
+        - HT
+        - HM
+        - VA
+        - HN
+        - HK
+        - HU
+        - IS
+        - IN
+        - ID
+        - IR
+        - IQ
+        - IE
+        - IM
+        - IL
+        - IT
+        - JM
+        - JP
+        - JE
+        - JO
+        - KZ
+        - KE
+        - KI
+        - KW
+        - KG
+        - LA
+        - LV
+        - LB
+        - LS
+        - LR
+        - LY
+        - LI
+        - LT
+        - LU
+        - MO
+        - MG
+        - MW
+        - MY
+        - MV
+        - ML
+        - MT
+        - MH
+        - MQ
+        - MR
+        - MU
+        - YT
+        - MX
+        - FM
+        - MD
+        - MC
+        - MN
+        - ME
+        - MS
+        - MA
+        - MZ
+        - MM
+        - NA
+        - NR
+        - NP
+        - NL
+        - NC
+        - NZ
+        - NI
+        - NE
+        - NG
+        - NU
+        - NF
+        - KP
+        - MK
+        - MP
+        - "NO"
+        - OM
+        - PK
+        - PW
+        - PS
+        - PA
+        - PG
+        - PY
+        - PE
+        - PH
+        - PN
+        - PL
+        - PT
+        - PR
+        - QA
+        - RE
+        - RO
+        - RU
+        - RW
+        - BL
+        - SH
+        - KN
+        - LC
+        - MF
+        - PM
+        - VC
+        - WS
+        - SM
+        - ST
+        - SA
+        - SN
+        - RS
+        - SC
+        - SL
+        - SG
+        - SX
+        - SK
+        - SI
+        - SB
+        - SO
+        - ZA
+        - GS
+        - KR
+        - SS
+        - ES
+        - LK
+        - SD
+        - SR
+        - SJ
+        - SE
+        - CH
+        - SY
+        - TW
+        - TJ
+        - TZ
+        - TH
+        - TL
+        - TG
+        - TK
+        - TO
+        - TT
+        - TN
+        - TR
+        - TM
+        - TC
+        - TV
+        - UG
+        - UA
+        - AE
+        - GB
+        - UM
+        - US
+        - UY
+        - UZ
+        - VU
+        - VE
+        - VN
+        - VG
+        - VI
+        - WF
+        - EH
+        - YE
+        - ZM
+        - ZW
       type: string
       description: |-
         * `AF` - Afghanistan
@@ -1126,258 +1156,293 @@ components:
         * `ZM` - Zambia
         * `ZW` - Zimbabwe
       x-enum-descriptions:
-      - Afghanistan
-      - Åland Islands
-      - Albania
-      - Algeria
-      - American Samoa
-      - Andorra
-      - Angola
-      - Anguilla
-      - Antarctica
-      - Antigua and Barbuda
-      - Argentina
-      - Armenia
-      - Aruba
-      - Australia
-      - Austria
-      - Azerbaijan
-      - Bahamas
-      - Bahrain
-      - Bangladesh
-      - Barbados
-      - Belarus
-      - Belgium
-      - Belize
-      - Benin
-      - Bermuda
-      - Bhutan
-      - Bolivia
-      - Bonaire, Sint Eustatius and Saba
-      - Bosnia and Herzegovina
-      - Botswana
-      - Bouvet Island
-      - Brazil
-      - British Indian Ocean Territory
-      - Brunei
-      - Bulgaria
-      - Burkina Faso
-      - Burundi
-      - Cabo Verde
-      - Cambodia
-      - Cameroon
-      - Canada
-      - Cayman Islands
-      - Central African Republic
-      - Chad
-      - Chile
-      - China
-      - Christmas Island
-      - Cocos (Keeling) Islands
-      - Colombia
-      - Comoros
-      - Congo
-      - Congo (the Democratic Republic of the)
-      - Cook Islands
-      - Costa Rica
-      - Côte d'Ivoire
-      - Croatia
-      - Cuba
-      - Curaçao
-      - Cyprus
-      - Czechia
-      - Denmark
-      - Djibouti
-      - Dominica
-      - Dominican Republic
-      - Ecuador
-      - Egypt
-      - El Salvador
-      - Equatorial Guinea
-      - Eritrea
-      - Estonia
-      - Eswatini
-      - Ethiopia
-      - Falkland Islands (Malvinas)
-      - Faroe Islands
-      - Fiji
-      - Finland
-      - France
-      - French Guiana
-      - French Polynesia
-      - French Southern Territories
-      - Gabon
-      - Gambia
-      - Georgia
-      - Germany
-      - Ghana
-      - Gibraltar
-      - Greece
-      - Greenland
-      - Grenada
-      - Guadeloupe
-      - Guam
-      - Guatemala
-      - Guernsey
-      - Guinea
-      - Guinea-Bissau
-      - Guyana
-      - Haiti
-      - Heard Island and McDonald Islands
-      - Holy See
-      - Honduras
-      - Hong Kong
-      - Hungary
-      - Iceland
-      - India
-      - Indonesia
-      - Iran
-      - Iraq
-      - Ireland
-      - Isle of Man
-      - Israel
-      - Italy
-      - Jamaica
-      - Japan
-      - Jersey
-      - Jordan
-      - Kazakhstan
-      - Kenya
-      - Kiribati
-      - Kuwait
-      - Kyrgyzstan
-      - Laos
-      - Latvia
-      - Lebanon
-      - Lesotho
-      - Liberia
-      - Libya
-      - Liechtenstein
-      - Lithuania
-      - Luxembourg
-      - Macao
-      - Madagascar
-      - Malawi
-      - Malaysia
-      - Maldives
-      - Mali
-      - Malta
-      - Marshall Islands
-      - Martinique
-      - Mauritania
-      - Mauritius
-      - Mayotte
-      - Mexico
-      - Micronesia
-      - Moldova
-      - Monaco
-      - Mongolia
-      - Montenegro
-      - Montserrat
-      - Morocco
-      - Mozambique
-      - Myanmar
-      - Namibia
-      - Nauru
-      - Nepal
-      - Netherlands
-      - New Caledonia
-      - New Zealand
-      - Nicaragua
-      - Niger
-      - Nigeria
-      - Niue
-      - Norfolk Island
-      - North Korea
-      - North Macedonia
-      - Northern Mariana Islands
-      - Norway
-      - Oman
-      - Pakistan
-      - Palau
-      - Palestine, State of
-      - Panama
-      - Papua New Guinea
-      - Paraguay
-      - Peru
-      - Philippines
-      - Pitcairn
-      - Poland
-      - Portugal
-      - Puerto Rico
-      - Qatar
-      - Réunion
-      - Romania
-      - Russia
-      - Rwanda
-      - Saint Barthélemy
-      - Saint Helena, Ascension and Tristan da Cunha
-      - Saint Kitts and Nevis
-      - Saint Lucia
-      - Saint Martin (French part)
-      - Saint Pierre and Miquelon
-      - Saint Vincent and the Grenadines
-      - Samoa
-      - San Marino
-      - Sao Tome and Principe
-      - Saudi Arabia
-      - Senegal
-      - Serbia
-      - Seychelles
-      - Sierra Leone
-      - Singapore
-      - Sint Maarten (Dutch part)
-      - Slovakia
-      - Slovenia
-      - Solomon Islands
-      - Somalia
-      - South Africa
-      - South Georgia and the South Sandwich Islands
-      - South Korea
-      - South Sudan
-      - Spain
-      - Sri Lanka
-      - Sudan
-      - Suriname
-      - Svalbard and Jan Mayen
-      - Sweden
-      - Switzerland
-      - Syria
-      - Taiwan
-      - Tajikistan
-      - Tanzania
-      - Thailand
-      - Timor-Leste
-      - Togo
-      - Tokelau
-      - Tonga
-      - Trinidad and Tobago
-      - Tunisia
-      - Türkiye
-      - Turkmenistan
-      - Turks and Caicos Islands
-      - Tuvalu
-      - Uganda
-      - Ukraine
-      - United Arab Emirates
-      - United Kingdom
-      - United States Minor Outlying Islands
-      - United States of America
-      - Uruguay
-      - Uzbekistan
-      - Vanuatu
-      - Venezuela
-      - Vietnam
-      - Virgin Islands (British)
-      - Virgin Islands (U.S.)
-      - Wallis and Futuna
-      - Western Sahara
-      - Yemen
-      - Zambia
-      - Zimbabwe
+        - Afghanistan
+        - Åland Islands
+        - Albania
+        - Algeria
+        - American Samoa
+        - Andorra
+        - Angola
+        - Anguilla
+        - Antarctica
+        - Antigua and Barbuda
+        - Argentina
+        - Armenia
+        - Aruba
+        - Australia
+        - Austria
+        - Azerbaijan
+        - Bahamas
+        - Bahrain
+        - Bangladesh
+        - Barbados
+        - Belarus
+        - Belgium
+        - Belize
+        - Benin
+        - Bermuda
+        - Bhutan
+        - Bolivia
+        - Bonaire, Sint Eustatius and Saba
+        - Bosnia and Herzegovina
+        - Botswana
+        - Bouvet Island
+        - Brazil
+        - British Indian Ocean Territory
+        - Brunei
+        - Bulgaria
+        - Burkina Faso
+        - Burundi
+        - Cabo Verde
+        - Cambodia
+        - Cameroon
+        - Canada
+        - Cayman Islands
+        - Central African Republic
+        - Chad
+        - Chile
+        - China
+        - Christmas Island
+        - Cocos (Keeling) Islands
+        - Colombia
+        - Comoros
+        - Congo
+        - Congo (the Democratic Republic of the)
+        - Cook Islands
+        - Costa Rica
+        - Côte d'Ivoire
+        - Croatia
+        - Cuba
+        - Curaçao
+        - Cyprus
+        - Czechia
+        - Denmark
+        - Djibouti
+        - Dominica
+        - Dominican Republic
+        - Ecuador
+        - Egypt
+        - El Salvador
+        - Equatorial Guinea
+        - Eritrea
+        - Estonia
+        - Eswatini
+        - Ethiopia
+        - Falkland Islands (Malvinas)
+        - Faroe Islands
+        - Fiji
+        - Finland
+        - France
+        - French Guiana
+        - French Polynesia
+        - French Southern Territories
+        - Gabon
+        - Gambia
+        - Georgia
+        - Germany
+        - Ghana
+        - Gibraltar
+        - Greece
+        - Greenland
+        - Grenada
+        - Guadeloupe
+        - Guam
+        - Guatemala
+        - Guernsey
+        - Guinea
+        - Guinea-Bissau
+        - Guyana
+        - Haiti
+        - Heard Island and McDonald Islands
+        - Holy See
+        - Honduras
+        - Hong Kong
+        - Hungary
+        - Iceland
+        - India
+        - Indonesia
+        - Iran
+        - Iraq
+        - Ireland
+        - Isle of Man
+        - Israel
+        - Italy
+        - Jamaica
+        - Japan
+        - Jersey
+        - Jordan
+        - Kazakhstan
+        - Kenya
+        - Kiribati
+        - Kuwait
+        - Kyrgyzstan
+        - Laos
+        - Latvia
+        - Lebanon
+        - Lesotho
+        - Liberia
+        - Libya
+        - Liechtenstein
+        - Lithuania
+        - Luxembourg
+        - Macao
+        - Madagascar
+        - Malawi
+        - Malaysia
+        - Maldives
+        - Mali
+        - Malta
+        - Marshall Islands
+        - Martinique
+        - Mauritania
+        - Mauritius
+        - Mayotte
+        - Mexico
+        - Micronesia
+        - Moldova
+        - Monaco
+        - Mongolia
+        - Montenegro
+        - Montserrat
+        - Morocco
+        - Mozambique
+        - Myanmar
+        - Namibia
+        - Nauru
+        - Nepal
+        - Netherlands
+        - New Caledonia
+        - New Zealand
+        - Nicaragua
+        - Niger
+        - Nigeria
+        - Niue
+        - Norfolk Island
+        - North Korea
+        - North Macedonia
+        - Northern Mariana Islands
+        - Norway
+        - Oman
+        - Pakistan
+        - Palau
+        - Palestine, State of
+        - Panama
+        - Papua New Guinea
+        - Paraguay
+        - Peru
+        - Philippines
+        - Pitcairn
+        - Poland
+        - Portugal
+        - Puerto Rico
+        - Qatar
+        - Réunion
+        - Romania
+        - Russia
+        - Rwanda
+        - Saint Barthélemy
+        - Saint Helena, Ascension and Tristan da Cunha
+        - Saint Kitts and Nevis
+        - Saint Lucia
+        - Saint Martin (French part)
+        - Saint Pierre and Miquelon
+        - Saint Vincent and the Grenadines
+        - Samoa
+        - San Marino
+        - Sao Tome and Principe
+        - Saudi Arabia
+        - Senegal
+        - Serbia
+        - Seychelles
+        - Sierra Leone
+        - Singapore
+        - Sint Maarten (Dutch part)
+        - Slovakia
+        - Slovenia
+        - Solomon Islands
+        - Somalia
+        - South Africa
+        - South Georgia and the South Sandwich Islands
+        - South Korea
+        - South Sudan
+        - Spain
+        - Sri Lanka
+        - Sudan
+        - Suriname
+        - Svalbard and Jan Mayen
+        - Sweden
+        - Switzerland
+        - Syria
+        - Taiwan
+        - Tajikistan
+        - Tanzania
+        - Thailand
+        - Timor-Leste
+        - Togo
+        - Tokelau
+        - Tonga
+        - Trinidad and Tobago
+        - Tunisia
+        - Türkiye
+        - Turkmenistan
+        - Turks and Caicos Islands
+        - Tuvalu
+        - Uganda
+        - Ukraine
+        - United Arab Emirates
+        - United Kingdom
+        - United States Minor Outlying Islands
+        - United States of America
+        - Uruguay
+        - Uzbekistan
+        - Vanuatu
+        - Venezuela
+        - Vietnam
+        - Virgin Islands (British)
+        - Virgin Islands (U.S.)
+        - Wallis and Futuna
+        - Western Sahara
+        - Yemen
+        - Zambia
+        - Zimbabwe
+    CreateBasketWithProductsRequest:
+      type: object
+      description: Serializer for creating a basket with products. (For OpenAPI spec.)
+      properties:
+        system_slug:
+          type: string
+          minLength: 1
+        skus:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateBasketWithProductsSkuRequest"
+        checkout:
+          type: boolean
+        discount_code:
+          type: string
+          minLength: 1
+      required:
+        - checkout
+        - discount_code
+        - skus
+        - system_slug
+    CreateBasketWithProductsSkuRequest:
+      type: object
+      description: Defines the schema for a SKU in the CreateBasketWithProductsSerializer.
+      properties:
+        sku:
+          type: string
+          minLength: 1
+        quantity:
+          type: integer
+          minimum: 1
+      required:
+        - quantity
+        - sku
     CyberSourceCheckout:
       type: object
-      description: Really basic serializer for the payload that we need to send to
+      description:
+        Really basic serializer for the payload that we need to send to
         CyberSource.
       properties:
         payload:
@@ -1388,9 +1453,9 @@ components:
         method:
           type: string
       required:
-      - method
-      - payload
-      - url
+        - method
+        - payload
+        - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -1408,8 +1473,8 @@ components:
         payment_type:
           nullable: true
           oneOf:
-          - $ref: '#/components/schemas/PaymentTypeEnum'
-          - $ref: '#/components/schemas/NullEnum'
+            - $ref: "#/components/schemas/PaymentTypeEnum"
+            - $ref: "#/components/schemas/NullEnum"
         max_redemptions:
           type: integer
           maximum: 2147483647
@@ -1419,46 +1484,48 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: If set, this discount code will not be redeemable before this
+          description:
+            If set, this discount code will not be redeemable before this
             date.
         expiration_date:
           type: string
           format: date-time
           nullable: true
-          description: If set, this discount code will not be redeemable after this
+          description:
+            If set, this discount code will not be redeemable after this
             date.
         integrated_system:
-          $ref: '#/components/schemas/IntegratedSystem'
+          $ref: "#/components/schemas/IntegratedSystem"
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
         assigned_users:
           type: array
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         company:
-          $ref: '#/components/schemas/Company'
+          $ref: "#/components/schemas/Company"
       required:
-      - amount
-      - assigned_users
-      - company
-      - discount_code
-      - id
-      - integrated_system
-      - product
+        - amount
+        - assigned_users
+        - company
+        - discount_code
+        - id
+        - integrated_system
+        - product
     DiscountTypeEnum:
       enum:
-      - percent-off
-      - dollars-off
-      - fixed-price
+        - percent-off
+        - dollars-off
+        - fixed-price
       type: string
       description: |-
         * `percent-off` - percent-off
         * `dollars-off` - dollars-off
         * `fixed-price` - fixed-price
       x-enum-descriptions:
-      - percent-off
-      - dollars-off
-      - fixed-price
+        - percent-off
+        - dollars-off
+        - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1476,8 +1543,8 @@ components:
         description:
           type: string
       required:
-      - id
-      - name
+        - id
+        - name
     IntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1493,7 +1560,7 @@ components:
         description:
           type: string
       required:
-      - name
+        - name
     Line:
       type: object
       description: Serializes a line item for an order.
@@ -1518,17 +1585,17 @@ components:
           format: decimal
           pattern: ^-?\d{0,7}(?:\.\d{0,2})?$
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
       required:
-      - id
-      - item_description
-      - product
-      - quantity
-      - total_price
-      - unit_price
+        - id
+        - item_description
+        - product
+        - quantity
+        - total_price
+        - unit_price
     NullEnum:
       enum:
-      - null
+        - null
     OrderHistory:
       type: object
       description: Serializer for order history.
@@ -1537,7 +1604,7 @@ components:
           type: integer
           readOnly: true
         state:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         reference_number:
           type: string
           maxLength: 255
@@ -1550,7 +1617,7 @@ components:
         lines:
           type: array
           items:
-            $ref: '#/components/schemas/Line'
+            $ref: "#/components/schemas/Line"
         created_on:
           type: string
           format: date-time
@@ -1560,17 +1627,17 @@ components:
           format: date-time
           readOnly: true
       required:
-      - created_on
-      - id
-      - lines
-      - purchaser
-      - total_price_paid
-      - updated_on
+        - created_on
+        - id
+        - lines
+        - purchaser
+        - total_price_paid
+        - updated_on
     PaginatedBasketWithProductList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1588,12 +1655,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/BasketWithProduct'
+            $ref: "#/components/schemas/BasketWithProduct"
     PaginatedIntegratedSystemList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1611,12 +1678,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/IntegratedSystem'
+            $ref: "#/components/schemas/IntegratedSystem"
     PaginatedOrderHistoryList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1634,12 +1701,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/OrderHistory'
+            $ref: "#/components/schemas/OrderHistory"
     PaginatedProductList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1657,7 +1724,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Product'
+            $ref: "#/components/schemas/Product"
     PatchedIntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1703,18 +1770,19 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
     PaymentTypeEnum:
       enum:
-      - marketing
-      - sales
-      - financial-assistance
-      - customer-support
-      - staff
-      - legacy
-      - credit_card
-      - purchase_order
+        - marketing
+        - sales
+        - financial-assistance
+        - customer-support
+        - staff
+        - legacy
+        - credit_card
+        - purchase_order
       type: string
       description: |-
         * `marketing` - marketing
@@ -1726,14 +1794,14 @@ components:
         * `credit_card` - credit_card
         * `purchase_order` - purchase_order
       x-enum-descriptions:
-      - marketing
-      - sales
-      - financial-assistance
-      - customer-support
-      - staff
-      - legacy
-      - credit_card
-      - purchase_order
+        - marketing
+        - sales
+        - financial-assistance
+        - customer-support
+        - staff
+        - legacy
+        - credit_card
+        - purchase_order
     Product:
       type: object
       description: Serializer for Product model.
@@ -1768,16 +1836,17 @@ components:
           readOnly: true
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
       required:
-      - deleted_by_cascade
-      - description
-      - id
-      - name
-      - price
-      - sku
-      - system
+        - deleted_by_cascade
+        - description
+        - id
+        - name
+        - price
+        - sku
+        - system
     ProductRequest:
       type: object
       description: Serializer for Product model.
@@ -1809,14 +1878,15 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
       required:
-      - description
-      - name
-      - price
-      - sku
-      - system
+        - description
+        - name
+        - price
+        - sku
+        - system
     SimpleDiscount:
       type: object
       description: Simpler serializer for discounts.
@@ -1832,7 +1902,7 @@ components:
           format: decimal
           pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
         discount_type:
-          $ref: '#/components/schemas/DiscountTypeEnum'
+          $ref: "#/components/schemas/DiscountTypeEnum"
         formatted_discount_amount:
           type: string
           description: |-
@@ -1841,20 +1911,20 @@ components:
             This quantizes percent discounts to whole numbers. This is probably fine.
           readOnly: true
       required:
-      - amount
-      - discount_code
-      - discount_type
-      - formatted_discount_amount
-      - id
+        - amount
+        - discount_code
+        - discount_type
+        - formatted_discount_amount
+        - id
     StateEnum:
       enum:
-      - pending
-      - fulfilled
-      - canceled
-      - refunded
-      - declined
-      - errored
-      - review
+        - pending
+        - fulfilled
+        - canceled
+        - refunded
+        - declined
+        - errored
+        - review
       type: string
       description: |-
         * `pending` - Pending
@@ -1865,13 +1935,13 @@ components:
         * `errored` - Errored
         * `review` - Review
       x-enum-descriptions:
-      - Pending
-      - Fulfilled
-      - Canceled
-      - Refunded
-      - Declined
-      - Errored
-      - Review
+        - Pending
+        - Fulfilled
+        - Canceled
+        - Refunded
+        - Declined
+        - Errored
+        - Review
     TaxRate:
       type: object
       description: TaxRate model serializer
@@ -1880,7 +1950,7 @@ components:
           type: integer
           readOnly: true
         country_code:
-          $ref: '#/components/schemas/CountryCodeEnum'
+          $ref: "#/components/schemas/CountryCodeEnum"
         tax_rate:
           type: string
           format: decimal
@@ -1889,8 +1959,8 @@ components:
           type: string
           maxLength: 100
       required:
-      - country_code
-      - id
+        - country_code
+        - id
     User:
       type: object
       description: Serializer for User model.
@@ -1900,7 +1970,8 @@ components:
           readOnly: true
         username:
           type: string
-          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+          description:
+            Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
@@ -1916,5 +1987,5 @@ components:
           type: string
           maxLength: 150
       required:
-      - id
-      - username
+        - id
+        - username

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9,557 +9,553 @@ paths:
       operationId: meta_integrated_system_list
       description: Viewset for IntegratedSystem model.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedIntegratedSystemList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedIntegratedSystemList'
+          description: ''
     post:
       operationId: meta_integrated_system_create
       description: Viewset for IntegratedSystem model.
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
         required: true
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
   /api/v0/meta/integrated_system/{id}/:
     get:
       operationId: meta_integrated_system_retrieve
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     put:
       operationId: meta_integrated_system_update
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     patch:
       operationId: meta_integrated_system_partial_update
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     delete:
       operationId: meta_integrated_system_destroy
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/meta/product/:
     get:
       operationId: meta_product_list
       description: Viewset for Product model.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - in: query
-          name: name
-          schema:
-            type: string
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
-        - in: query
-          name: system__slug
-          schema:
-            type: string
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: system__slug
+        schema:
+          type: string
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedProductList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedProductList'
+          description: ''
     post:
       operationId: meta_product_create
       description: Viewset for Product model.
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
         required: true
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
   /api/v0/meta/product/{id}/:
     get:
       operationId: meta_product_retrieve
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     put:
       operationId: meta_product_update
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     patch:
       operationId: meta_product_partial_update
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     delete:
       operationId: meta_product_destroy
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/payments/baskets/:
     get:
       operationId: payments_baskets_list
       description: Retrives the current user's baskets, one per system.
       parameters:
-        - in: query
-          name: integrated_system
-          schema:
-            type: integer
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - in: query
+        name: integrated_system
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedBasketWithProductList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedBasketWithProductList'
+          description: ''
   /api/v0/payments/baskets/{id}/:
     get:
       operationId: payments_baskets_retrieve
       description: Retrieve a basket for the current user.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/add_discount/{system_slug}/:
     post:
       operationId: payments_baskets_add_discount_create
-      description:
-        Creates or updates a basket for the current user, adding the discount
+      description: Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
-        - in: query
-          name: discount_code
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: query
+        name: discount_code
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/clear/{system_slug}/:
     delete:
       operationId: payments_baskets_clear_destroy
       description: Clears the basket for the current user.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/:
     post:
       operationId: payments_baskets_create_from_product_create
-      description:
-        Creates or updates a basket for the current user, adding the selected
+      description: Creates or updates a basket for the current user, adding the selected
         product.
       parameters:
-        - in: path
-          name: sku
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/create_with_products/:
     post:
       operationId: payments_baskets_create_with_products_create
-      description:
-        Creates or updates a basket for the current user, adding the selected
+      description: Creates or updates a basket for the current user, adding the selected
         product.
       tags:
-        - payments
+      - payments
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/for_system/{system_slug}/:
     get:
       operationId: payments_baskets_for_system_retrieve
       description: Returns or creates a basket for the current user and system.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/checkout/{system_slug}/:
     post:
       operationId: payments_checkout_create
-      description:
-        Generates and returns the form payload for the current basket for
+      description: Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CyberSourceCheckout"
-          description: ""
+                $ref: '#/components/schemas/CyberSourceCheckout'
+          description: ''
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create
       description: Create a discount.
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Discount"
-          description: ""
+                $ref: '#/components/schemas/Discount'
+          description: ''
   /api/v0/payments/orders/history/:
     get:
       operationId: payments_orders_history_list
       description: Retrives the current user's completed orders.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedOrderHistoryList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedOrderHistoryList'
+          description: ''
   /api/v0/payments/orders/history/{id}/:
     get:
       operationId: payments_orders_history_retrieve
       description: Retrieve a completed order for the current user.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrderHistory"
-          description: ""
+                $ref: '#/components/schemas/OrderHistory'
+          description: ''
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
       description: User retrieve and update viewsets for the current user
       tags:
-        - users
+      - users
       security:
-        - {}
+      - {}
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
-          description: ""
+                $ref: '#/components/schemas/User'
+          description: ''
 components:
   schemas:
     BasketItemWithProduct:
@@ -567,7 +563,7 @@ components:
       description: Basket item model serializer with product information
       properties:
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
         id:
           type: integer
           readOnly: true
@@ -591,14 +587,14 @@ components:
           minimum: 0
         discount_applied:
           allOf:
-            - $ref: "#/components/schemas/SimpleDiscount"
+          - $ref: '#/components/schemas/SimpleDiscount'
           readOnly: true
       required:
-        - discount_applied
-        - discounted_price
-        - id
-        - price
-        - product
+      - discount_applied
+      - discounted_price
+      - id
+      - price
+      - product
     BasketWithProduct:
       type: object
       description: Basket model serializer with items and products
@@ -609,11 +605,11 @@ components:
         user:
           type: integer
         integrated_system:
-          $ref: "#/components/schemas/IntegratedSystem"
+          $ref: '#/components/schemas/IntegratedSystem'
         basket_items:
           type: array
           items:
-            $ref: "#/components/schemas/BasketItemWithProduct"
+            $ref: '#/components/schemas/BasketItemWithProduct'
         subtotal:
           type: number
           format: double
@@ -625,21 +621,21 @@ components:
           description: Get the tax for the basket
           readOnly: true
         tax_rate:
-          $ref: "#/components/schemas/TaxRate"
+          $ref: '#/components/schemas/TaxRate'
         total_price:
           type: number
           format: double
           description: Get the total price for the basket
           readOnly: true
       required:
-        - basket_items
-        - id
-        - integrated_system
-        - subtotal
-        - tax
-        - tax_rate
-        - total_price
-        - user
+      - basket_items
+      - id
+      - integrated_system
+      - subtotal
+      - tax
+      - tax_rate
+      - total_price
+      - user
     Company:
       type: object
       description: Serializer for companies.
@@ -651,259 +647,259 @@ components:
           type: string
           maxLength: 255
       required:
-        - id
-        - name
+      - id
+      - name
     CountryCodeEnum:
       enum:
-        - AF
-        - AX
-        - AL
-        - DZ
-        - AS
-        - AD
-        - AO
-        - AI
-        - AQ
-        - AG
-        - AR
-        - AM
-        - AW
-        - AU
-        - AT
-        - AZ
-        - BS
-        - BH
-        - BD
-        - BB
-        - BY
-        - BE
-        - BZ
-        - BJ
-        - BM
-        - BT
-        - BO
-        - BQ
-        - BA
-        - BW
-        - BV
-        - BR
-        - IO
-        - BN
-        - BG
-        - BF
-        - BI
-        - CV
-        - KH
-        - CM
-        - CA
-        - KY
-        - CF
-        - TD
-        - CL
-        - CN
-        - CX
-        - CC
-        - CO
-        - KM
-        - CG
-        - CD
-        - CK
-        - CR
-        - CI
-        - HR
-        - CU
-        - CW
-        - CY
-        - CZ
-        - DK
-        - DJ
-        - DM
-        - DO
-        - EC
-        - EG
-        - SV
-        - GQ
-        - ER
-        - EE
-        - SZ
-        - ET
-        - FK
-        - FO
-        - FJ
-        - FI
-        - FR
-        - GF
-        - PF
-        - TF
-        - GA
-        - GM
-        - GE
-        - DE
-        - GH
-        - GI
-        - GR
-        - GL
-        - GD
-        - GP
-        - GU
-        - GT
-        - GG
-        - GN
-        - GW
-        - GY
-        - HT
-        - HM
-        - VA
-        - HN
-        - HK
-        - HU
-        - IS
-        - IN
-        - ID
-        - IR
-        - IQ
-        - IE
-        - IM
-        - IL
-        - IT
-        - JM
-        - JP
-        - JE
-        - JO
-        - KZ
-        - KE
-        - KI
-        - KW
-        - KG
-        - LA
-        - LV
-        - LB
-        - LS
-        - LR
-        - LY
-        - LI
-        - LT
-        - LU
-        - MO
-        - MG
-        - MW
-        - MY
-        - MV
-        - ML
-        - MT
-        - MH
-        - MQ
-        - MR
-        - MU
-        - YT
-        - MX
-        - FM
-        - MD
-        - MC
-        - MN
-        - ME
-        - MS
-        - MA
-        - MZ
-        - MM
-        - NA
-        - NR
-        - NP
-        - NL
-        - NC
-        - NZ
-        - NI
-        - NE
-        - NG
-        - NU
-        - NF
-        - KP
-        - MK
-        - MP
-        - "NO"
-        - OM
-        - PK
-        - PW
-        - PS
-        - PA
-        - PG
-        - PY
-        - PE
-        - PH
-        - PN
-        - PL
-        - PT
-        - PR
-        - QA
-        - RE
-        - RO
-        - RU
-        - RW
-        - BL
-        - SH
-        - KN
-        - LC
-        - MF
-        - PM
-        - VC
-        - WS
-        - SM
-        - ST
-        - SA
-        - SN
-        - RS
-        - SC
-        - SL
-        - SG
-        - SX
-        - SK
-        - SI
-        - SB
-        - SO
-        - ZA
-        - GS
-        - KR
-        - SS
-        - ES
-        - LK
-        - SD
-        - SR
-        - SJ
-        - SE
-        - CH
-        - SY
-        - TW
-        - TJ
-        - TZ
-        - TH
-        - TL
-        - TG
-        - TK
-        - TO
-        - TT
-        - TN
-        - TR
-        - TM
-        - TC
-        - TV
-        - UG
-        - UA
-        - AE
-        - GB
-        - UM
-        - US
-        - UY
-        - UZ
-        - VU
-        - VE
-        - VN
-        - VG
-        - VI
-        - WF
-        - EH
-        - YE
-        - ZM
-        - ZW
+      - AF
+      - AX
+      - AL
+      - DZ
+      - AS
+      - AD
+      - AO
+      - AI
+      - AQ
+      - AG
+      - AR
+      - AM
+      - AW
+      - AU
+      - AT
+      - AZ
+      - BS
+      - BH
+      - BD
+      - BB
+      - BY
+      - BE
+      - BZ
+      - BJ
+      - BM
+      - BT
+      - BO
+      - BQ
+      - BA
+      - BW
+      - BV
+      - BR
+      - IO
+      - BN
+      - BG
+      - BF
+      - BI
+      - CV
+      - KH
+      - CM
+      - CA
+      - KY
+      - CF
+      - TD
+      - CL
+      - CN
+      - CX
+      - CC
+      - CO
+      - KM
+      - CG
+      - CD
+      - CK
+      - CR
+      - CI
+      - HR
+      - CU
+      - CW
+      - CY
+      - CZ
+      - DK
+      - DJ
+      - DM
+      - DO
+      - EC
+      - EG
+      - SV
+      - GQ
+      - ER
+      - EE
+      - SZ
+      - ET
+      - FK
+      - FO
+      - FJ
+      - FI
+      - FR
+      - GF
+      - PF
+      - TF
+      - GA
+      - GM
+      - GE
+      - DE
+      - GH
+      - GI
+      - GR
+      - GL
+      - GD
+      - GP
+      - GU
+      - GT
+      - GG
+      - GN
+      - GW
+      - GY
+      - HT
+      - HM
+      - VA
+      - HN
+      - HK
+      - HU
+      - IS
+      - IN
+      - ID
+      - IR
+      - IQ
+      - IE
+      - IM
+      - IL
+      - IT
+      - JM
+      - JP
+      - JE
+      - JO
+      - KZ
+      - KE
+      - KI
+      - KW
+      - KG
+      - LA
+      - LV
+      - LB
+      - LS
+      - LR
+      - LY
+      - LI
+      - LT
+      - LU
+      - MO
+      - MG
+      - MW
+      - MY
+      - MV
+      - ML
+      - MT
+      - MH
+      - MQ
+      - MR
+      - MU
+      - YT
+      - MX
+      - FM
+      - MD
+      - MC
+      - MN
+      - ME
+      - MS
+      - MA
+      - MZ
+      - MM
+      - NA
+      - NR
+      - NP
+      - NL
+      - NC
+      - NZ
+      - NI
+      - NE
+      - NG
+      - NU
+      - NF
+      - KP
+      - MK
+      - MP
+      - 'NO'
+      - OM
+      - PK
+      - PW
+      - PS
+      - PA
+      - PG
+      - PY
+      - PE
+      - PH
+      - PN
+      - PL
+      - PT
+      - PR
+      - QA
+      - RE
+      - RO
+      - RU
+      - RW
+      - BL
+      - SH
+      - KN
+      - LC
+      - MF
+      - PM
+      - VC
+      - WS
+      - SM
+      - ST
+      - SA
+      - SN
+      - RS
+      - SC
+      - SL
+      - SG
+      - SX
+      - SK
+      - SI
+      - SB
+      - SO
+      - ZA
+      - GS
+      - KR
+      - SS
+      - ES
+      - LK
+      - SD
+      - SR
+      - SJ
+      - SE
+      - CH
+      - SY
+      - TW
+      - TJ
+      - TZ
+      - TH
+      - TL
+      - TG
+      - TK
+      - TO
+      - TT
+      - TN
+      - TR
+      - TM
+      - TC
+      - TV
+      - UG
+      - UA
+      - AE
+      - GB
+      - UM
+      - US
+      - UY
+      - UZ
+      - VU
+      - VE
+      - VN
+      - VG
+      - VI
+      - WF
+      - EH
+      - YE
+      - ZM
+      - ZW
       type: string
       description: |-
         * `AF` - Afghanistan
@@ -1156,255 +1152,255 @@ components:
         * `ZM` - Zambia
         * `ZW` - Zimbabwe
       x-enum-descriptions:
-        - Afghanistan
-        - Åland Islands
-        - Albania
-        - Algeria
-        - American Samoa
-        - Andorra
-        - Angola
-        - Anguilla
-        - Antarctica
-        - Antigua and Barbuda
-        - Argentina
-        - Armenia
-        - Aruba
-        - Australia
-        - Austria
-        - Azerbaijan
-        - Bahamas
-        - Bahrain
-        - Bangladesh
-        - Barbados
-        - Belarus
-        - Belgium
-        - Belize
-        - Benin
-        - Bermuda
-        - Bhutan
-        - Bolivia
-        - Bonaire, Sint Eustatius and Saba
-        - Bosnia and Herzegovina
-        - Botswana
-        - Bouvet Island
-        - Brazil
-        - British Indian Ocean Territory
-        - Brunei
-        - Bulgaria
-        - Burkina Faso
-        - Burundi
-        - Cabo Verde
-        - Cambodia
-        - Cameroon
-        - Canada
-        - Cayman Islands
-        - Central African Republic
-        - Chad
-        - Chile
-        - China
-        - Christmas Island
-        - Cocos (Keeling) Islands
-        - Colombia
-        - Comoros
-        - Congo
-        - Congo (the Democratic Republic of the)
-        - Cook Islands
-        - Costa Rica
-        - Côte d'Ivoire
-        - Croatia
-        - Cuba
-        - Curaçao
-        - Cyprus
-        - Czechia
-        - Denmark
-        - Djibouti
-        - Dominica
-        - Dominican Republic
-        - Ecuador
-        - Egypt
-        - El Salvador
-        - Equatorial Guinea
-        - Eritrea
-        - Estonia
-        - Eswatini
-        - Ethiopia
-        - Falkland Islands (Malvinas)
-        - Faroe Islands
-        - Fiji
-        - Finland
-        - France
-        - French Guiana
-        - French Polynesia
-        - French Southern Territories
-        - Gabon
-        - Gambia
-        - Georgia
-        - Germany
-        - Ghana
-        - Gibraltar
-        - Greece
-        - Greenland
-        - Grenada
-        - Guadeloupe
-        - Guam
-        - Guatemala
-        - Guernsey
-        - Guinea
-        - Guinea-Bissau
-        - Guyana
-        - Haiti
-        - Heard Island and McDonald Islands
-        - Holy See
-        - Honduras
-        - Hong Kong
-        - Hungary
-        - Iceland
-        - India
-        - Indonesia
-        - Iran
-        - Iraq
-        - Ireland
-        - Isle of Man
-        - Israel
-        - Italy
-        - Jamaica
-        - Japan
-        - Jersey
-        - Jordan
-        - Kazakhstan
-        - Kenya
-        - Kiribati
-        - Kuwait
-        - Kyrgyzstan
-        - Laos
-        - Latvia
-        - Lebanon
-        - Lesotho
-        - Liberia
-        - Libya
-        - Liechtenstein
-        - Lithuania
-        - Luxembourg
-        - Macao
-        - Madagascar
-        - Malawi
-        - Malaysia
-        - Maldives
-        - Mali
-        - Malta
-        - Marshall Islands
-        - Martinique
-        - Mauritania
-        - Mauritius
-        - Mayotte
-        - Mexico
-        - Micronesia
-        - Moldova
-        - Monaco
-        - Mongolia
-        - Montenegro
-        - Montserrat
-        - Morocco
-        - Mozambique
-        - Myanmar
-        - Namibia
-        - Nauru
-        - Nepal
-        - Netherlands
-        - New Caledonia
-        - New Zealand
-        - Nicaragua
-        - Niger
-        - Nigeria
-        - Niue
-        - Norfolk Island
-        - North Korea
-        - North Macedonia
-        - Northern Mariana Islands
-        - Norway
-        - Oman
-        - Pakistan
-        - Palau
-        - Palestine, State of
-        - Panama
-        - Papua New Guinea
-        - Paraguay
-        - Peru
-        - Philippines
-        - Pitcairn
-        - Poland
-        - Portugal
-        - Puerto Rico
-        - Qatar
-        - Réunion
-        - Romania
-        - Russia
-        - Rwanda
-        - Saint Barthélemy
-        - Saint Helena, Ascension and Tristan da Cunha
-        - Saint Kitts and Nevis
-        - Saint Lucia
-        - Saint Martin (French part)
-        - Saint Pierre and Miquelon
-        - Saint Vincent and the Grenadines
-        - Samoa
-        - San Marino
-        - Sao Tome and Principe
-        - Saudi Arabia
-        - Senegal
-        - Serbia
-        - Seychelles
-        - Sierra Leone
-        - Singapore
-        - Sint Maarten (Dutch part)
-        - Slovakia
-        - Slovenia
-        - Solomon Islands
-        - Somalia
-        - South Africa
-        - South Georgia and the South Sandwich Islands
-        - South Korea
-        - South Sudan
-        - Spain
-        - Sri Lanka
-        - Sudan
-        - Suriname
-        - Svalbard and Jan Mayen
-        - Sweden
-        - Switzerland
-        - Syria
-        - Taiwan
-        - Tajikistan
-        - Tanzania
-        - Thailand
-        - Timor-Leste
-        - Togo
-        - Tokelau
-        - Tonga
-        - Trinidad and Tobago
-        - Tunisia
-        - Türkiye
-        - Turkmenistan
-        - Turks and Caicos Islands
-        - Tuvalu
-        - Uganda
-        - Ukraine
-        - United Arab Emirates
-        - United Kingdom
-        - United States Minor Outlying Islands
-        - United States of America
-        - Uruguay
-        - Uzbekistan
-        - Vanuatu
-        - Venezuela
-        - Vietnam
-        - Virgin Islands (British)
-        - Virgin Islands (U.S.)
-        - Wallis and Futuna
-        - Western Sahara
-        - Yemen
-        - Zambia
-        - Zimbabwe
+      - Afghanistan
+      - Åland Islands
+      - Albania
+      - Algeria
+      - American Samoa
+      - Andorra
+      - Angola
+      - Anguilla
+      - Antarctica
+      - Antigua and Barbuda
+      - Argentina
+      - Armenia
+      - Aruba
+      - Australia
+      - Austria
+      - Azerbaijan
+      - Bahamas
+      - Bahrain
+      - Bangladesh
+      - Barbados
+      - Belarus
+      - Belgium
+      - Belize
+      - Benin
+      - Bermuda
+      - Bhutan
+      - Bolivia
+      - Bonaire, Sint Eustatius and Saba
+      - Bosnia and Herzegovina
+      - Botswana
+      - Bouvet Island
+      - Brazil
+      - British Indian Ocean Territory
+      - Brunei
+      - Bulgaria
+      - Burkina Faso
+      - Burundi
+      - Cabo Verde
+      - Cambodia
+      - Cameroon
+      - Canada
+      - Cayman Islands
+      - Central African Republic
+      - Chad
+      - Chile
+      - China
+      - Christmas Island
+      - Cocos (Keeling) Islands
+      - Colombia
+      - Comoros
+      - Congo
+      - Congo (the Democratic Republic of the)
+      - Cook Islands
+      - Costa Rica
+      - Côte d'Ivoire
+      - Croatia
+      - Cuba
+      - Curaçao
+      - Cyprus
+      - Czechia
+      - Denmark
+      - Djibouti
+      - Dominica
+      - Dominican Republic
+      - Ecuador
+      - Egypt
+      - El Salvador
+      - Equatorial Guinea
+      - Eritrea
+      - Estonia
+      - Eswatini
+      - Ethiopia
+      - Falkland Islands (Malvinas)
+      - Faroe Islands
+      - Fiji
+      - Finland
+      - France
+      - French Guiana
+      - French Polynesia
+      - French Southern Territories
+      - Gabon
+      - Gambia
+      - Georgia
+      - Germany
+      - Ghana
+      - Gibraltar
+      - Greece
+      - Greenland
+      - Grenada
+      - Guadeloupe
+      - Guam
+      - Guatemala
+      - Guernsey
+      - Guinea
+      - Guinea-Bissau
+      - Guyana
+      - Haiti
+      - Heard Island and McDonald Islands
+      - Holy See
+      - Honduras
+      - Hong Kong
+      - Hungary
+      - Iceland
+      - India
+      - Indonesia
+      - Iran
+      - Iraq
+      - Ireland
+      - Isle of Man
+      - Israel
+      - Italy
+      - Jamaica
+      - Japan
+      - Jersey
+      - Jordan
+      - Kazakhstan
+      - Kenya
+      - Kiribati
+      - Kuwait
+      - Kyrgyzstan
+      - Laos
+      - Latvia
+      - Lebanon
+      - Lesotho
+      - Liberia
+      - Libya
+      - Liechtenstein
+      - Lithuania
+      - Luxembourg
+      - Macao
+      - Madagascar
+      - Malawi
+      - Malaysia
+      - Maldives
+      - Mali
+      - Malta
+      - Marshall Islands
+      - Martinique
+      - Mauritania
+      - Mauritius
+      - Mayotte
+      - Mexico
+      - Micronesia
+      - Moldova
+      - Monaco
+      - Mongolia
+      - Montenegro
+      - Montserrat
+      - Morocco
+      - Mozambique
+      - Myanmar
+      - Namibia
+      - Nauru
+      - Nepal
+      - Netherlands
+      - New Caledonia
+      - New Zealand
+      - Nicaragua
+      - Niger
+      - Nigeria
+      - Niue
+      - Norfolk Island
+      - North Korea
+      - North Macedonia
+      - Northern Mariana Islands
+      - Norway
+      - Oman
+      - Pakistan
+      - Palau
+      - Palestine, State of
+      - Panama
+      - Papua New Guinea
+      - Paraguay
+      - Peru
+      - Philippines
+      - Pitcairn
+      - Poland
+      - Portugal
+      - Puerto Rico
+      - Qatar
+      - Réunion
+      - Romania
+      - Russia
+      - Rwanda
+      - Saint Barthélemy
+      - Saint Helena, Ascension and Tristan da Cunha
+      - Saint Kitts and Nevis
+      - Saint Lucia
+      - Saint Martin (French part)
+      - Saint Pierre and Miquelon
+      - Saint Vincent and the Grenadines
+      - Samoa
+      - San Marino
+      - Sao Tome and Principe
+      - Saudi Arabia
+      - Senegal
+      - Serbia
+      - Seychelles
+      - Sierra Leone
+      - Singapore
+      - Sint Maarten (Dutch part)
+      - Slovakia
+      - Slovenia
+      - Solomon Islands
+      - Somalia
+      - South Africa
+      - South Georgia and the South Sandwich Islands
+      - South Korea
+      - South Sudan
+      - Spain
+      - Sri Lanka
+      - Sudan
+      - Suriname
+      - Svalbard and Jan Mayen
+      - Sweden
+      - Switzerland
+      - Syria
+      - Taiwan
+      - Tajikistan
+      - Tanzania
+      - Thailand
+      - Timor-Leste
+      - Togo
+      - Tokelau
+      - Tonga
+      - Trinidad and Tobago
+      - Tunisia
+      - Türkiye
+      - Turkmenistan
+      - Turks and Caicos Islands
+      - Tuvalu
+      - Uganda
+      - Ukraine
+      - United Arab Emirates
+      - United Kingdom
+      - United States Minor Outlying Islands
+      - United States of America
+      - Uruguay
+      - Uzbekistan
+      - Vanuatu
+      - Venezuela
+      - Vietnam
+      - Virgin Islands (British)
+      - Virgin Islands (U.S.)
+      - Wallis and Futuna
+      - Western Sahara
+      - Yemen
+      - Zambia
+      - Zimbabwe
     CreateBasketWithProductsRequest:
       type: object
       description: Serializer for creating a basket with products. (For OpenAPI spec.)
@@ -1415,17 +1411,17 @@ components:
         skus:
           type: array
           items:
-            $ref: "#/components/schemas/CreateBasketWithProductsSkuRequest"
+            $ref: '#/components/schemas/CreateBasketWithProductsSkuRequest'
         checkout:
           type: boolean
         discount_code:
           type: string
           minLength: 1
       required:
-        - checkout
-        - discount_code
-        - skus
-        - system_slug
+      - checkout
+      - discount_code
+      - skus
+      - system_slug
     CreateBasketWithProductsSkuRequest:
       type: object
       description: Defines the schema for a SKU in the CreateBasketWithProductsSerializer.
@@ -1437,12 +1433,11 @@ components:
           type: integer
           minimum: 1
       required:
-        - quantity
-        - sku
+      - quantity
+      - sku
     CyberSourceCheckout:
       type: object
-      description:
-        Really basic serializer for the payload that we need to send to
+      description: Really basic serializer for the payload that we need to send to
         CyberSource.
       properties:
         payload:
@@ -1453,9 +1448,9 @@ components:
         method:
           type: string
       required:
-        - method
-        - payload
-        - url
+      - method
+      - payload
+      - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -1473,8 +1468,8 @@ components:
         payment_type:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/PaymentTypeEnum"
-            - $ref: "#/components/schemas/NullEnum"
+          - $ref: '#/components/schemas/PaymentTypeEnum'
+          - $ref: '#/components/schemas/NullEnum'
         max_redemptions:
           type: integer
           maximum: 2147483647
@@ -1484,48 +1479,46 @@ components:
           type: string
           format: date-time
           nullable: true
-          description:
-            If set, this discount code will not be redeemable before this
+          description: If set, this discount code will not be redeemable before this
             date.
         expiration_date:
           type: string
           format: date-time
           nullable: true
-          description:
-            If set, this discount code will not be redeemable after this
+          description: If set, this discount code will not be redeemable after this
             date.
         integrated_system:
-          $ref: "#/components/schemas/IntegratedSystem"
+          $ref: '#/components/schemas/IntegratedSystem'
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
         assigned_users:
           type: array
           items:
-            $ref: "#/components/schemas/User"
+            $ref: '#/components/schemas/User'
         company:
-          $ref: "#/components/schemas/Company"
+          $ref: '#/components/schemas/Company'
       required:
-        - amount
-        - assigned_users
-        - company
-        - discount_code
-        - id
-        - integrated_system
-        - product
+      - amount
+      - assigned_users
+      - company
+      - discount_code
+      - id
+      - integrated_system
+      - product
     DiscountTypeEnum:
       enum:
-        - percent-off
-        - dollars-off
-        - fixed-price
+      - percent-off
+      - dollars-off
+      - fixed-price
       type: string
       description: |-
         * `percent-off` - percent-off
         * `dollars-off` - dollars-off
         * `fixed-price` - fixed-price
       x-enum-descriptions:
-        - percent-off
-        - dollars-off
-        - fixed-price
+      - percent-off
+      - dollars-off
+      - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1543,8 +1536,8 @@ components:
         description:
           type: string
       required:
-        - id
-        - name
+      - id
+      - name
     IntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1560,7 +1553,7 @@ components:
         description:
           type: string
       required:
-        - name
+      - name
     Line:
       type: object
       description: Serializes a line item for an order.
@@ -1585,17 +1578,17 @@ components:
           format: decimal
           pattern: ^-?\d{0,7}(?:\.\d{0,2})?$
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
       required:
-        - id
-        - item_description
-        - product
-        - quantity
-        - total_price
-        - unit_price
+      - id
+      - item_description
+      - product
+      - quantity
+      - total_price
+      - unit_price
     NullEnum:
       enum:
-        - null
+      - null
     OrderHistory:
       type: object
       description: Serializer for order history.
@@ -1604,7 +1597,7 @@ components:
           type: integer
           readOnly: true
         state:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         reference_number:
           type: string
           maxLength: 255
@@ -1617,7 +1610,7 @@ components:
         lines:
           type: array
           items:
-            $ref: "#/components/schemas/Line"
+            $ref: '#/components/schemas/Line'
         created_on:
           type: string
           format: date-time
@@ -1627,17 +1620,17 @@ components:
           format: date-time
           readOnly: true
       required:
-        - created_on
-        - id
-        - lines
-        - purchaser
-        - total_price_paid
-        - updated_on
+      - created_on
+      - id
+      - lines
+      - purchaser
+      - total_price_paid
+      - updated_on
     PaginatedBasketWithProductList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1655,12 +1648,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/BasketWithProduct"
+            $ref: '#/components/schemas/BasketWithProduct'
     PaginatedIntegratedSystemList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1678,12 +1671,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/IntegratedSystem"
+            $ref: '#/components/schemas/IntegratedSystem'
     PaginatedOrderHistoryList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1701,12 +1694,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/OrderHistory"
+            $ref: '#/components/schemas/OrderHistory'
     PaginatedProductList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1724,7 +1717,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Product"
+            $ref: '#/components/schemas/Product'
     PatchedIntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1770,19 +1763,18 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
     PaymentTypeEnum:
       enum:
-        - marketing
-        - sales
-        - financial-assistance
-        - customer-support
-        - staff
-        - legacy
-        - credit_card
-        - purchase_order
+      - marketing
+      - sales
+      - financial-assistance
+      - customer-support
+      - staff
+      - legacy
+      - credit_card
+      - purchase_order
       type: string
       description: |-
         * `marketing` - marketing
@@ -1794,14 +1786,14 @@ components:
         * `credit_card` - credit_card
         * `purchase_order` - purchase_order
       x-enum-descriptions:
-        - marketing
-        - sales
-        - financial-assistance
-        - customer-support
-        - staff
-        - legacy
-        - credit_card
-        - purchase_order
+      - marketing
+      - sales
+      - financial-assistance
+      - customer-support
+      - staff
+      - legacy
+      - credit_card
+      - purchase_order
     Product:
       type: object
       description: Serializer for Product model.
@@ -1836,17 +1828,16 @@ components:
           readOnly: true
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
       required:
-        - deleted_by_cascade
-        - description
-        - id
-        - name
-        - price
-        - sku
-        - system
+      - deleted_by_cascade
+      - description
+      - id
+      - name
+      - price
+      - sku
+      - system
     ProductRequest:
       type: object
       description: Serializer for Product model.
@@ -1878,15 +1869,14 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
       required:
-        - description
-        - name
-        - price
-        - sku
-        - system
+      - description
+      - name
+      - price
+      - sku
+      - system
     SimpleDiscount:
       type: object
       description: Simpler serializer for discounts.
@@ -1902,7 +1892,7 @@ components:
           format: decimal
           pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
         discount_type:
-          $ref: "#/components/schemas/DiscountTypeEnum"
+          $ref: '#/components/schemas/DiscountTypeEnum'
         formatted_discount_amount:
           type: string
           description: |-
@@ -1911,20 +1901,20 @@ components:
             This quantizes percent discounts to whole numbers. This is probably fine.
           readOnly: true
       required:
-        - amount
-        - discount_code
-        - discount_type
-        - formatted_discount_amount
-        - id
+      - amount
+      - discount_code
+      - discount_type
+      - formatted_discount_amount
+      - id
     StateEnum:
       enum:
-        - pending
-        - fulfilled
-        - canceled
-        - refunded
-        - declined
-        - errored
-        - review
+      - pending
+      - fulfilled
+      - canceled
+      - refunded
+      - declined
+      - errored
+      - review
       type: string
       description: |-
         * `pending` - Pending
@@ -1935,13 +1925,13 @@ components:
         * `errored` - Errored
         * `review` - Review
       x-enum-descriptions:
-        - Pending
-        - Fulfilled
-        - Canceled
-        - Refunded
-        - Declined
-        - Errored
-        - Review
+      - Pending
+      - Fulfilled
+      - Canceled
+      - Refunded
+      - Declined
+      - Errored
+      - Review
     TaxRate:
       type: object
       description: TaxRate model serializer
@@ -1950,7 +1940,7 @@ components:
           type: integer
           readOnly: true
         country_code:
-          $ref: "#/components/schemas/CountryCodeEnum"
+          $ref: '#/components/schemas/CountryCodeEnum'
         tax_rate:
           type: string
           format: decimal
@@ -1959,8 +1949,8 @@ components:
           type: string
           maxLength: 100
       required:
-        - country_code
-        - id
+      - country_code
+      - id
     User:
       type: object
       description: Serializer for User model.
@@ -1970,8 +1960,7 @@ components:
           readOnly: true
         username:
           type: string
-          description:
-            Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
@@ -1987,5 +1976,5 @@ components:
           type: string
           maxLength: 150
       required:
-        - id
-        - username
+      - id
+      - username

--- a/payments/serializers/v0/__init__.py
+++ b/payments/serializers/v0/__init__.py
@@ -373,3 +373,19 @@ class CyberSourceCheckoutSerializer(serializers.Serializer):
     payload = serializers.DictField()
     url = serializers.CharField()
     method = serializers.CharField()
+
+
+class CreateBasketWithProductsSkuSerializer(serializers.Serializer):
+    """Defines the schema for a SKU in the CreateBasketWithProductsSerializer."""
+
+    sku = serializers.CharField()
+    quantity = serializers.IntegerField(min_value=1)
+
+
+class CreateBasketWithProductsSerializer(serializers.Serializer):
+    """Serializer for creating a basket with products. (For OpenAPI spec.)"""
+
+    system_slug = serializers.CharField()
+    skus = CreateBasketWithProductsSkuSerializer(many=True)
+    checkout = serializers.BooleanField()
+    discount_code = serializers.CharField()

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -30,6 +30,7 @@ from payments.models import Basket, BasketItem, Discount, Order
 from payments.permissions import HasIntegratedSystemAPIKey
 from payments.serializers.v0 import (
     BasketWithProductSerializer,
+    CreateBasketWithProductsSerializer,
     CyberSourceCheckoutSerializer,
     DiscountSerializer,
     OrderHistorySerializer,
@@ -167,7 +168,6 @@ def create_basket_from_product(request, system_slug: str, sku: str):
         )
 
     try:
-        log.debug("attempting to run basket_add")
         pm.hook.basket_add(request=request, basket=basket, basket_item=product)
     except ProductBlockedError:
         return Response(
@@ -181,6 +181,96 @@ def create_basket_from_product(request, system_slug: str, sku: str):
     auto_apply_discount_discounts = api.get_auto_apply_discounts_for_basket(basket.id)
     for discount in auto_apply_discount_discounts:
         basket.apply_discount_to_basket(discount)
+    basket.refresh_from_db()
+
+    if checkout:
+        return redirect("checkout_interstitial_page", system_slug=system.slug)
+
+    return Response(
+        BasketWithProductSerializer(basket).data,
+        status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+    )
+
+
+@extend_schema(
+    description=(
+        "Creates or updates a basket for the current user, "
+        "adding the selected product."
+    ),
+    methods=["POST"],
+    responses=BasketWithProductSerializer,
+    request=CreateBasketWithProductsSerializer,
+)
+@api_view(["POST"])
+@permission_classes((IsAuthenticated,))
+def create_basket_with_products(request):
+    """
+    Create new basket items for the currently logged in user. Reuse the existing
+    basket object if it exists. Optionally apply the specified discount.
+
+    If the checkout flag is set in the POST data, then this will create the
+    basket, then immediately flip the user to the checkout interstitial (which
+    then redirects to the payment gateway).
+
+    If any of the products aren't found, this will return a 404 error. If
+    the discount code is invalid, the discount won't be applied and an error
+    will be logged, but the basket will still be updated.
+
+    POST Args:
+        system_slug (str): system slug
+        quantity (int): quantity of the product to add to the basket (defaults to 1)
+        checkout (bool): redirect to checkout interstitial (defaults to False)
+        skus (list[str]): list of product SKUs to add to the basket
+        discount_code (str): discount code to apply to the basket
+
+    Returns:
+        Response: HTTP response
+    """
+    system_slug = request.data.get("system_slug")
+    checkout = request.data.get("checkout", False)
+    discount_code = request.data.get("discount_code", None)
+    skus = request.data.get("skus", [])
+
+    system = IntegratedSystem.objects.get(slug=system_slug)
+    basket = Basket.establish_basket(request, system)
+    products = []
+
+    try:
+        products = [
+            (
+                Product.objects.get(system=system, sku=sku["sku"]),
+                sku["quantity"],
+            )
+            for sku in skus
+        ]
+    except Product.DoesNotExist:
+        return Response(
+            {"error": "Product not found"}, status=status.HTTP_404_NOT_FOUND
+        )
+
+    try:
+        for product, quantity in products:
+            pm.hook.basket_add(request=request, basket=basket, basket_item=product)
+            (_, created) = BasketItem.objects.update_or_create(
+                basket=basket, product=product, defaults={"quantity": quantity}
+            )
+    except ProductBlockedError:
+        return Response(
+            {"error": "Product blocked from purchasing.", "product": product},
+            status=status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS,
+        )
+
+    auto_apply_discount_discounts = api.get_auto_apply_discounts_for_basket(basket.id)
+    for discount in auto_apply_discount_discounts:
+        basket.apply_discount_to_basket(discount)
+
+    if discount_code:
+        try:
+            discount = Discount.objects.get(discount_code=discount_code)
+            basket.apply_discount_to_basket(discount)
+        except Discount.DoesNotExist:
+            pass
+
     basket.refresh_from_db()
 
     if checkout:

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -251,7 +251,7 @@ def create_basket_with_products(request):
     try:
         for product, quantity in products:
             pm.hook.basket_add(request=request, basket=basket, basket_item=product)
-            (_, created) = BasketItem.objects.update_or_create(
+            BasketItem.objects.update_or_create(
                 basket=basket, product=product, defaults={"quantity": quantity}
             )
     except ProductBlockedError:
@@ -278,7 +278,7 @@ def create_basket_with_products(request):
 
     return Response(
         BasketWithProductSerializer(basket).data,
-        status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        status=status.HTTP_200_OK,
     )
 
 

--- a/payments/views/v0/urls.py
+++ b/payments/views/v0/urls.py
@@ -11,6 +11,7 @@ from payments.views.v0 import (
     add_discount_to_basket,
     clear_basket,
     create_basket_from_product,
+    create_basket_with_products,
     get_user_basket_for_system,
     start_checkout,
 )
@@ -32,6 +33,11 @@ urlpatterns = [
         "baskets/create_from_product/<str:system_slug>/<str:sku>/",
         create_basket_from_product,
         name="create_from_product",
+    ),
+    path(
+        "baskets/create_with_products/",
+        create_basket_with_products,
+        name="create_with_products",
     ),
     path(
         "baskets/clear/<str:system_slug>/",

--- a/payments/views/v0/v0_test.py
+++ b/payments/views/v0/v0_test.py
@@ -2,32 +2,59 @@
 
 import pytest
 
-from payments.factories import ProductFactory
+from payments.factories import BasketFactory, DiscountFactory, ProductFactory
 from payments.models import Basket
 from system_meta.factories import ActiveIntegratedSystemFactory
 
 pytestmark = pytest.mark.django_db
 
 
-def test_create_basket_with_products(mocker, user_client):
+@pytest.mark.parametrize(
+    ("existing_basket", "add_discount", "bad_product"),
+    [(True, False, False), (False, True, False), (False, False, True)],
+)
+def test_create_basket_with_products(
+    mocker, user, user_client, existing_basket, add_discount, bad_product
+):
     """Test creating a basket with products."""
 
     mocker.patch("payments.api.send_pre_sale_webhook")
     system = ActiveIntegratedSystemFactory()
-    products = ProductFactory.create_batch(size=2, system=system)
+    if bad_product:
+        products = ProductFactory.create_batch(size=2)
+    else:
+        products = ProductFactory.create_batch(size=2, system=system)
+
+    basket = (
+        BasketFactory(user=user, integrated_system=system) if existing_basket else None
+    )
 
     url = "/api/v0/payments/baskets/create_with_products/"
+    payload = {
+        "system_slug": system.slug,
+        "skus": [{"sku": product.sku, "quantity": 1} for product in products],
+    }
+
+    if add_discount:
+        discount = DiscountFactory(discount_type="fixed-price", amount=100)
+        payload["discount_code"] = discount.discount_code
+
     response = user_client.post(
         url,
-        data={
-            "system_slug": system.slug,
-            "skus": [{"sku": product.sku, "quantity": 1} for product in products],
-        },
+        data=payload,
     )
-    assert response.status_code in (
-        200,
-        201,
-    )
+
+    if bad_product:
+        assert response.status_code == 404
+        return
+
+    assert response.status_code == 200
 
     basket_id = response.data["id"]
     assert Basket.objects.get(id=basket_id).basket_items.count() == 2
+
+    if existing_basket:
+        assert basket_id == basket.id
+
+    if add_discount:
+        assert discount in Basket.objects.get(id=basket_id).discounts.all()

--- a/payments/views/v0/v0_test.py
+++ b/payments/views/v0/v0_test.py
@@ -1,0 +1,33 @@
+"""View tests for the v0 API."""
+
+import pytest
+
+from payments.factories import ProductFactory
+from payments.models import Basket
+from system_meta.factories import ActiveIntegratedSystemFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_create_basket_with_products(mocker, user_client):
+    """Test creating a basket with products."""
+
+    mocker.patch("payments.api.send_pre_sale_webhook")
+    system = ActiveIntegratedSystemFactory()
+    products = ProductFactory.create_batch(size=2, system=system)
+
+    url = "/api/v0/payments/baskets/create_with_products/"
+    response = user_client.post(
+        url,
+        data={
+            "system_slug": system.slug,
+            "skus": [{"sku": product.sku, "quantity": 1} for product in products],
+        },
+    )
+    assert response.status_code in (
+        200,
+        201,
+    )
+
+    basket_id = response.data["id"]
+    assert Basket.objects.get(id=basket_id).basket_items.count() == 2


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#6327

### Description (What does it do?)

Adds a `create_with_products` API to U which allows for adding multiple products to the basket in one go. Products must all be within the same integrated system. Specifying products that either don't exist or aren't in the integrated system will cause a 400 error. 

This new API can also take a discount code. Specifying a discount code that doesn't exist will just not do anything - it will not stop the process.

### How can this be tested?

Automated tests should pass.

We don't have UI that exposes this functionality right now so the best way to test is by using the Swagger UI. You should be able to get to that at http://ue.odl.local:9080/api/v0/schema/swagger-ui/#/payments/payments_baskets_create_with_products_create - fill out the payload, and you should get a valid basket back with the items in it (once you've logged in). 

### Additional Context

We support specifying the quantity for items added to the cart (generally, but you have to specify it for this API). This should be 1 in most cases. Quantities will matter more when we build in products for xPRO but for regular single-learner verified enrollments, a quantity greater than 1 will just result in the user being charged more.

As per usual, calling this for a user that doesn't have a basket for the given system will create it. It will also trigger all the usual hookimpls that happen when you add a single item to the cart too. (If a learner adds several products and one of them is blocked for the country they're in, the process stops but the basket will have the items that were successfully added to that point in it.) 