### PR TITLE
Update add product API to allow for a discount to be specified

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -4222,16 +4222,24 @@ export const PaymentsApiAxiosParamCreator = function (
     },
     /**
      * Creates or updates a basket for the current user, adding the selected product.
+     * @param {string} discount_code
      * @param {string} sku
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     paymentsBasketsCreateFromProductCreate: async (
+      discount_code: string,
       sku: string,
       system_slug: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
+      // verify required parameter 'discount_code' is not null or undefined
+      assertParamExists(
+        "paymentsBasketsCreateFromProductCreate",
+        "discount_code",
+        discount_code,
+      )
       // verify required parameter 'sku' is not null or undefined
       assertParamExists("paymentsBasketsCreateFromProductCreate", "sku", sku)
       // verify required parameter 'system_slug' is not null or undefined
@@ -4241,7 +4249,11 @@ export const PaymentsApiAxiosParamCreator = function (
         system_slug,
       )
       const localVarPath =
-        `/api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/`
+        `/api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/`
+          .replace(
+            `{${"discount_code"}}`,
+            encodeURIComponent(String(discount_code)),
+          )
           .replace(`{${"sku"}}`, encodeURIComponent(String(sku)))
           .replace(
             `{${"system_slug"}}`,
@@ -4735,12 +4747,14 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
     },
     /**
      * Creates or updates a basket for the current user, adding the selected product.
+     * @param {string} discount_code
      * @param {string} sku
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async paymentsBasketsCreateFromProductCreate(
+      discount_code: string,
       sku: string,
       system_slug: string,
       options?: RawAxiosRequestConfig,
@@ -4752,6 +4766,7 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.paymentsBasketsCreateFromProductCreate(
+          discount_code,
           sku,
           system_slug,
           options,
@@ -5076,6 +5091,7 @@ export const PaymentsApiFactory = function (
     ): AxiosPromise<BasketWithProduct> {
       return localVarFp
         .paymentsBasketsCreateFromProductCreate(
+          requestParameters.discount_code,
           requestParameters.sku,
           requestParameters.system_slug,
           options,
@@ -5251,6 +5267,13 @@ export interface PaymentsApiPaymentsBasketsClearDestroyRequest {
  * @interface PaymentsApiPaymentsBasketsCreateFromProductCreateRequest
  */
 export interface PaymentsApiPaymentsBasketsCreateFromProductCreateRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate
+   */
+  readonly discount_code: string
+
   /**
    *
    * @type {string}
@@ -5441,6 +5464,7 @@ export class PaymentsApi extends BaseAPI {
   ) {
     return PaymentsApiFp(this.configuration)
       .paymentsBasketsCreateFromProductCreate(
+        requestParameters.discount_code,
         requestParameters.sku,
         requestParameters.system_slug,
         options,

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -4222,13 +4222,69 @@ export const PaymentsApiAxiosParamCreator = function (
     },
     /**
      * Creates or updates a basket for the current user, adding the selected product.
-     * @param {string} discount_code
      * @param {string} sku
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     paymentsBasketsCreateFromProductCreate: async (
+      sku: string,
+      system_slug: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'sku' is not null or undefined
+      assertParamExists("paymentsBasketsCreateFromProductCreate", "sku", sku)
+      // verify required parameter 'system_slug' is not null or undefined
+      assertParamExists(
+        "paymentsBasketsCreateFromProductCreate",
+        "system_slug",
+        system_slug,
+      )
+      const localVarPath =
+        `/api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/`
+          .replace(`{${"sku"}}`, encodeURIComponent(String(sku)))
+          .replace(
+            `{${"system_slug"}}`,
+            encodeURIComponent(String(system_slug)),
+          )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "POST",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * Creates or updates a basket for the current user, adding the selected product.
+     * @param {string} discount_code
+     * @param {string} sku
+     * @param {string} system_slug
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    paymentsBasketsCreateFromProductCreate2: async (
       discount_code: string,
       sku: string,
       system_slug: string,
@@ -4236,15 +4292,15 @@ export const PaymentsApiAxiosParamCreator = function (
     ): Promise<RequestArgs> => {
       // verify required parameter 'discount_code' is not null or undefined
       assertParamExists(
-        "paymentsBasketsCreateFromProductCreate",
+        "paymentsBasketsCreateFromProductCreate2",
         "discount_code",
         discount_code,
       )
       // verify required parameter 'sku' is not null or undefined
-      assertParamExists("paymentsBasketsCreateFromProductCreate", "sku", sku)
+      assertParamExists("paymentsBasketsCreateFromProductCreate2", "sku", sku)
       // verify required parameter 'system_slug' is not null or undefined
       assertParamExists(
-        "paymentsBasketsCreateFromProductCreate",
+        "paymentsBasketsCreateFromProductCreate2",
         "system_slug",
         system_slug,
       )
@@ -4747,14 +4803,12 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
     },
     /**
      * Creates or updates a basket for the current user, adding the selected product.
-     * @param {string} discount_code
      * @param {string} sku
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async paymentsBasketsCreateFromProductCreate(
-      discount_code: string,
       sku: string,
       system_slug: string,
       options?: RawAxiosRequestConfig,
@@ -4766,7 +4820,6 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.paymentsBasketsCreateFromProductCreate(
-          discount_code,
           sku,
           system_slug,
           options,
@@ -4786,12 +4839,25 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
     },
     /**
      * Creates or updates a basket for the current user, adding the selected product.
+<<<<<<< HEAD
      * @param {CreateBasketWithProductsRequest} CreateBasketWithProductsRequest
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async paymentsBasketsCreateWithProductsCreate(
       CreateBasketWithProductsRequest: CreateBasketWithProductsRequest,
+=======
+     * @param {string} discount_code
+     * @param {string} sku
+     * @param {string} system_slug
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async paymentsBasketsCreateFromProductCreate2(
+      discount_code: string,
+      sku: string,
+      system_slug: string,
+>>>>>>> b889362 (updating openapi spec)
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -4800,14 +4866,25 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
       ) => AxiosPromise<BasketWithProduct>
     > {
       const localVarAxiosArgs =
+<<<<<<< HEAD
         await localVarAxiosParamCreator.paymentsBasketsCreateWithProductsCreate(
           CreateBasketWithProductsRequest,
+=======
+        await localVarAxiosParamCreator.paymentsBasketsCreateFromProductCreate2(
+          discount_code,
+          sku,
+          system_slug,
+>>>>>>> b889362 (updating openapi spec)
           options,
         )
       const index = configuration?.serverIndex ?? 0
       const operationBasePath =
         operationServerMap[
+<<<<<<< HEAD
           "PaymentsApi.paymentsBasketsCreateWithProductsCreate"
+=======
+          "PaymentsApi.paymentsBasketsCreateFromProductCreate2"
+>>>>>>> b889362 (updating openapi spec)
         ]?.[index]?.url
       return (axios, basePath) =>
         createRequestFunction(
@@ -5091,6 +5168,24 @@ export const PaymentsApiFactory = function (
     ): AxiosPromise<BasketWithProduct> {
       return localVarFp
         .paymentsBasketsCreateFromProductCreate(
+          requestParameters.sku,
+          requestParameters.system_slug,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     * Creates or updates a basket for the current user, adding the selected product.
+     * @param {PaymentsApiPaymentsBasketsCreateFromProductCreate2Request} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    paymentsBasketsCreateFromProductCreate2(
+      requestParameters: PaymentsApiPaymentsBasketsCreateFromProductCreate2Request,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<BasketWithProduct> {
+      return localVarFp
+        .paymentsBasketsCreateFromProductCreate2(
           requestParameters.discount_code,
           requestParameters.sku,
           requestParameters.system_slug,
@@ -5272,13 +5367,6 @@ export interface PaymentsApiPaymentsBasketsCreateFromProductCreateRequest {
    * @type {string}
    * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate
    */
-  readonly discount_code: string
-
-  /**
-   *
-   * @type {string}
-   * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate
-   */
   readonly sku: string
 
   /**
@@ -5290,6 +5378,7 @@ export interface PaymentsApiPaymentsBasketsCreateFromProductCreateRequest {
 }
 
 /**
+<<<<<<< HEAD
  * Request parameters for paymentsBasketsCreateWithProductsCreate operation in PaymentsApi.
  * @export
  * @interface PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest
@@ -5301,6 +5390,33 @@ export interface PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest {
    * @memberof PaymentsApiPaymentsBasketsCreateWithProductsCreate
    */
   readonly CreateBasketWithProductsRequest: CreateBasketWithProductsRequest
+=======
+ * Request parameters for paymentsBasketsCreateFromProductCreate2 operation in PaymentsApi.
+ * @export
+ * @interface PaymentsApiPaymentsBasketsCreateFromProductCreate2Request
+ */
+export interface PaymentsApiPaymentsBasketsCreateFromProductCreate2Request {
+  /**
+   *
+   * @type {string}
+   * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate2
+   */
+  readonly discount_code: string
+
+  /**
+   *
+   * @type {string}
+   * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate2
+   */
+  readonly sku: string
+
+  /**
+   *
+   * @type {string}
+   * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate2
+   */
+  readonly system_slug: string
+>>>>>>> b889362 (updating openapi spec)
 }
 
 /**
@@ -5464,6 +5580,26 @@ export class PaymentsApi extends BaseAPI {
   ) {
     return PaymentsApiFp(this.configuration)
       .paymentsBasketsCreateFromProductCreate(
+        requestParameters.sku,
+        requestParameters.system_slug,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Creates or updates a basket for the current user, adding the selected product.
+   * @param {PaymentsApiPaymentsBasketsCreateFromProductCreate2Request} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof PaymentsApi
+   */
+  public paymentsBasketsCreateFromProductCreate2(
+    requestParameters: PaymentsApiPaymentsBasketsCreateFromProductCreate2Request,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return PaymentsApiFp(this.configuration)
+      .paymentsBasketsCreateFromProductCreate2(
         requestParameters.discount_code,
         requestParameters.sku,
         requestParameters.system_slug,

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -4109,6 +4109,74 @@ export const PaymentsApiAxiosParamCreator = function (
 ) {
   return {
     /**
+     * Creates or updates a basket for the current user, adding the selected product and discount.
+     * @param {string} discount_code
+     * @param {string} sku
+     * @param {string} system_slug
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createBasketFromProductWithDiscount: async (
+      discount_code: string,
+      sku: string,
+      system_slug: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'discount_code' is not null or undefined
+      assertParamExists(
+        "createBasketFromProductWithDiscount",
+        "discount_code",
+        discount_code,
+      )
+      // verify required parameter 'sku' is not null or undefined
+      assertParamExists("createBasketFromProductWithDiscount", "sku", sku)
+      // verify required parameter 'system_slug' is not null or undefined
+      assertParamExists(
+        "createBasketFromProductWithDiscount",
+        "system_slug",
+        system_slug,
+      )
+      const localVarPath =
+        `/api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/`
+          .replace(
+            `{${"discount_code"}}`,
+            encodeURIComponent(String(discount_code)),
+          )
+          .replace(`{${"sku"}}`, encodeURIComponent(String(sku)))
+          .replace(
+            `{${"system_slug"}}`,
+            encodeURIComponent(String(system_slug)),
+          )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "POST",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
      * Creates or updates a basket for the current user, adding the discount if valid.
      * @param {string} discount_code
      * @param {string} system_slug
@@ -4277,6 +4345,7 @@ export const PaymentsApiAxiosParamCreator = function (
       }
     },
     /**
+<<<<<<< HEAD
      * Creates or updates a basket for the current user, adding the selected product.
      * @param {string} discount_code
      * @param {string} sku
@@ -4398,6 +4467,8 @@ export const PaymentsApiAxiosParamCreator = function (
       }
     },
     /**
+=======
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
      * Returns or creates a basket for the current user and system.
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
@@ -4737,6 +4808,45 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
   const localVarAxiosParamCreator = PaymentsApiAxiosParamCreator(configuration)
   return {
     /**
+     * Creates or updates a basket for the current user, adding the selected product and discount.
+     * @param {string} discount_code
+     * @param {string} sku
+     * @param {string} system_slug
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async createBasketFromProductWithDiscount(
+      discount_code: string,
+      sku: string,
+      system_slug: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<BasketWithProduct>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.createBasketFromProductWithDiscount(
+          discount_code,
+          sku,
+          system_slug,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["PaymentsApi.createBasketFromProductWithDiscount"]?.[
+          index
+        ]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
      * Creates or updates a basket for the current user, adding the discount if valid.
      * @param {string} discount_code
      * @param {string} system_slug
@@ -4838,6 +4948,7 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
         )(axios, operationBasePath || basePath)
     },
     /**
+<<<<<<< HEAD
      * Creates or updates a basket for the current user, adding the selected product.
 <<<<<<< HEAD
      * @param {CreateBasketWithProductsRequest} CreateBasketWithProductsRequest
@@ -4895,6 +5006,8 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
         )(axios, operationBasePath || basePath)
     },
     /**
+=======
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
      * Returns or creates a basket for the current user and system.
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
@@ -5125,6 +5238,25 @@ export const PaymentsApiFactory = function (
   const localVarFp = PaymentsApiFp(configuration)
   return {
     /**
+     * Creates or updates a basket for the current user, adding the selected product and discount.
+     * @param {PaymentsApiCreateBasketFromProductWithDiscountRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createBasketFromProductWithDiscount(
+      requestParameters: PaymentsApiCreateBasketFromProductWithDiscountRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<BasketWithProduct> {
+      return localVarFp
+        .createBasketFromProductWithDiscount(
+          requestParameters.discount_code,
+          requestParameters.sku,
+          requestParameters.system_slug,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+    /**
      * Creates or updates a basket for the current user, adding the discount if valid.
      * @param {PaymentsApiPaymentsBasketsAddDiscountCreateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -5175,6 +5307,7 @@ export const PaymentsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
+<<<<<<< HEAD
      * Creates or updates a basket for the current user, adding the selected product.
      * @param {PaymentsApiPaymentsBasketsCreateFromProductCreate2Request} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -5211,6 +5344,8 @@ export const PaymentsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
+=======
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
      * Returns or creates a basket for the current user and system.
      * @param {PaymentsApiPaymentsBasketsForSystemRetrieveRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -5322,6 +5457,34 @@ export const PaymentsApiFactory = function (
 }
 
 /**
+ * Request parameters for createBasketFromProductWithDiscount operation in PaymentsApi.
+ * @export
+ * @interface PaymentsApiCreateBasketFromProductWithDiscountRequest
+ */
+export interface PaymentsApiCreateBasketFromProductWithDiscountRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof PaymentsApiCreateBasketFromProductWithDiscount
+   */
+  readonly discount_code: string
+
+  /**
+   *
+   * @type {string}
+   * @memberof PaymentsApiCreateBasketFromProductWithDiscount
+   */
+  readonly sku: string
+
+  /**
+   *
+   * @type {string}
+   * @memberof PaymentsApiCreateBasketFromProductWithDiscount
+   */
+  readonly system_slug: string
+}
+
+/**
  * Request parameters for paymentsBasketsAddDiscountCreate operation in PaymentsApi.
  * @export
  * @interface PaymentsApiPaymentsBasketsAddDiscountCreateRequest
@@ -5379,6 +5542,7 @@ export interface PaymentsApiPaymentsBasketsCreateFromProductCreateRequest {
 
 /**
 <<<<<<< HEAD
+<<<<<<< HEAD
  * Request parameters for paymentsBasketsCreateWithProductsCreate operation in PaymentsApi.
  * @export
  * @interface PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest
@@ -5420,6 +5584,8 @@ export interface PaymentsApiPaymentsBasketsCreateFromProductCreate2Request {
 }
 
 /**
+=======
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
  * Request parameters for paymentsBasketsForSystemRetrieve operation in PaymentsApi.
  * @export
  * @interface PaymentsApiPaymentsBasketsForSystemRetrieveRequest
@@ -5532,6 +5698,27 @@ export interface PaymentsApiPaymentsOrdersHistoryRetrieveRequest {
  */
 export class PaymentsApi extends BaseAPI {
   /**
+   * Creates or updates a basket for the current user, adding the selected product and discount.
+   * @param {PaymentsApiCreateBasketFromProductWithDiscountRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof PaymentsApi
+   */
+  public createBasketFromProductWithDiscount(
+    requestParameters: PaymentsApiCreateBasketFromProductWithDiscountRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return PaymentsApiFp(this.configuration)
+      .createBasketFromProductWithDiscount(
+        requestParameters.discount_code,
+        requestParameters.sku,
+        requestParameters.system_slug,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
    * Creates or updates a basket for the current user, adding the discount if valid.
    * @param {PaymentsApiPaymentsBasketsAddDiscountCreateRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
@@ -5588,6 +5775,7 @@ export class PaymentsApi extends BaseAPI {
   }
 
   /**
+<<<<<<< HEAD
    * Creates or updates a basket for the current user, adding the selected product.
    * @param {PaymentsApiPaymentsBasketsCreateFromProductCreate2Request} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
@@ -5628,6 +5816,8 @@ export class PaymentsApi extends BaseAPI {
   }
 
   /**
+=======
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
    * Returns or creates a basket for the current user and system.
    * @param {PaymentsApiPaymentsBasketsForSystemRetrieveRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -4345,75 +4345,6 @@ export const PaymentsApiAxiosParamCreator = function (
       }
     },
     /**
-<<<<<<< HEAD
-     * Creates or updates a basket for the current user, adding the selected product.
-     * @param {string} discount_code
-     * @param {string} sku
-     * @param {string} system_slug
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    paymentsBasketsCreateFromProductCreate2: async (
-      discount_code: string,
-      sku: string,
-      system_slug: string,
-      options: RawAxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'discount_code' is not null or undefined
-      assertParamExists(
-        "paymentsBasketsCreateFromProductCreate2",
-        "discount_code",
-        discount_code,
-      )
-      // verify required parameter 'sku' is not null or undefined
-      assertParamExists("paymentsBasketsCreateFromProductCreate2", "sku", sku)
-      // verify required parameter 'system_slug' is not null or undefined
-      assertParamExists(
-        "paymentsBasketsCreateFromProductCreate2",
-        "system_slug",
-        system_slug,
-      )
-      const localVarPath =
-        `/api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/`
-          .replace(
-            `{${"discount_code"}}`,
-            encodeURIComponent(String(discount_code)),
-          )
-          .replace(`{${"sku"}}`, encodeURIComponent(String(sku)))
-          .replace(
-            `{${"system_slug"}}`,
-            encodeURIComponent(String(system_slug)),
-          )
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "POST",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * Creates or updates a basket for the current user, adding the selected product.
      * @param {CreateBasketWithProductsRequest} CreateBasketWithProductsRequest
      * @param {*} [options] Override http request option.
@@ -4467,8 +4398,6 @@ export const PaymentsApiAxiosParamCreator = function (
       }
     },
     /**
-=======
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
      * Returns or creates a basket for the current user and system.
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
@@ -4948,27 +4877,13 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
         )(axios, operationBasePath || basePath)
     },
     /**
-<<<<<<< HEAD
      * Creates or updates a basket for the current user, adding the selected product.
-<<<<<<< HEAD
      * @param {CreateBasketWithProductsRequest} CreateBasketWithProductsRequest
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async paymentsBasketsCreateWithProductsCreate(
       CreateBasketWithProductsRequest: CreateBasketWithProductsRequest,
-=======
-     * @param {string} discount_code
-     * @param {string} sku
-     * @param {string} system_slug
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async paymentsBasketsCreateFromProductCreate2(
-      discount_code: string,
-      sku: string,
-      system_slug: string,
->>>>>>> b889362 (updating openapi spec)
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -4977,25 +4892,14 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
       ) => AxiosPromise<BasketWithProduct>
     > {
       const localVarAxiosArgs =
-<<<<<<< HEAD
         await localVarAxiosParamCreator.paymentsBasketsCreateWithProductsCreate(
           CreateBasketWithProductsRequest,
-=======
-        await localVarAxiosParamCreator.paymentsBasketsCreateFromProductCreate2(
-          discount_code,
-          sku,
-          system_slug,
->>>>>>> b889362 (updating openapi spec)
           options,
         )
       const index = configuration?.serverIndex ?? 0
       const operationBasePath =
         operationServerMap[
-<<<<<<< HEAD
           "PaymentsApi.paymentsBasketsCreateWithProductsCreate"
-=======
-          "PaymentsApi.paymentsBasketsCreateFromProductCreate2"
->>>>>>> b889362 (updating openapi spec)
         ]?.[index]?.url
       return (axios, basePath) =>
         createRequestFunction(
@@ -5006,8 +4910,6 @@ export const PaymentsApiFp = function (configuration?: Configuration) {
         )(axios, operationBasePath || basePath)
     },
     /**
-=======
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
      * Returns or creates a basket for the current user and system.
      * @param {string} system_slug
      * @param {*} [options] Override http request option.
@@ -5307,26 +5209,6 @@ export const PaymentsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-<<<<<<< HEAD
-     * Creates or updates a basket for the current user, adding the selected product.
-     * @param {PaymentsApiPaymentsBasketsCreateFromProductCreate2Request} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    paymentsBasketsCreateFromProductCreate2(
-      requestParameters: PaymentsApiPaymentsBasketsCreateFromProductCreate2Request,
-      options?: RawAxiosRequestConfig,
-    ): AxiosPromise<BasketWithProduct> {
-      return localVarFp
-        .paymentsBasketsCreateFromProductCreate2(
-          requestParameters.discount_code,
-          requestParameters.sku,
-          requestParameters.system_slug,
-          options,
-        )
-        .then((request) => request(axios, basePath))
-    },
-    /**
      * Creates or updates a basket for the current user, adding the selected product.
      * @param {PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -5344,8 +5226,6 @@ export const PaymentsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-=======
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
      * Returns or creates a basket for the current user and system.
      * @param {PaymentsApiPaymentsBasketsForSystemRetrieveRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -5541,8 +5421,6 @@ export interface PaymentsApiPaymentsBasketsCreateFromProductCreateRequest {
 }
 
 /**
-<<<<<<< HEAD
-<<<<<<< HEAD
  * Request parameters for paymentsBasketsCreateWithProductsCreate operation in PaymentsApi.
  * @export
  * @interface PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest
@@ -5554,38 +5432,9 @@ export interface PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest {
    * @memberof PaymentsApiPaymentsBasketsCreateWithProductsCreate
    */
   readonly CreateBasketWithProductsRequest: CreateBasketWithProductsRequest
-=======
- * Request parameters for paymentsBasketsCreateFromProductCreate2 operation in PaymentsApi.
- * @export
- * @interface PaymentsApiPaymentsBasketsCreateFromProductCreate2Request
- */
-export interface PaymentsApiPaymentsBasketsCreateFromProductCreate2Request {
-  /**
-   *
-   * @type {string}
-   * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate2
-   */
-  readonly discount_code: string
-
-  /**
-   *
-   * @type {string}
-   * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate2
-   */
-  readonly sku: string
-
-  /**
-   *
-   * @type {string}
-   * @memberof PaymentsApiPaymentsBasketsCreateFromProductCreate2
-   */
-  readonly system_slug: string
->>>>>>> b889362 (updating openapi spec)
 }
 
 /**
-=======
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
  * Request parameters for paymentsBasketsForSystemRetrieve operation in PaymentsApi.
  * @export
  * @interface PaymentsApiPaymentsBasketsForSystemRetrieveRequest
@@ -5775,28 +5624,6 @@ export class PaymentsApi extends BaseAPI {
   }
 
   /**
-<<<<<<< HEAD
-   * Creates or updates a basket for the current user, adding the selected product.
-   * @param {PaymentsApiPaymentsBasketsCreateFromProductCreate2Request} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof PaymentsApi
-   */
-  public paymentsBasketsCreateFromProductCreate2(
-    requestParameters: PaymentsApiPaymentsBasketsCreateFromProductCreate2Request,
-    options?: RawAxiosRequestConfig,
-  ) {
-    return PaymentsApiFp(this.configuration)
-      .paymentsBasketsCreateFromProductCreate2(
-        requestParameters.discount_code,
-        requestParameters.sku,
-        requestParameters.system_slug,
-        options,
-      )
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
    * Creates or updates a basket for the current user, adding the selected product.
    * @param {PaymentsApiPaymentsBasketsCreateWithProductsCreateRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
@@ -5816,8 +5643,6 @@ export class PaymentsApi extends BaseAPI {
   }
 
   /**
-=======
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
    * Returns or creates a basket for the current user and system.
    * @param {PaymentsApiPaymentsBasketsForSystemRetrieveRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9,448 +9,441 @@ paths:
       operationId: meta_integrated_system_list
       description: Viewset for IntegratedSystem model.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedIntegratedSystemList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedIntegratedSystemList'
+          description: ''
     post:
       operationId: meta_integrated_system_create
       description: Viewset for IntegratedSystem model.
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
         required: true
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
   /api/v0/meta/integrated_system/{id}/:
     get:
       operationId: meta_integrated_system_retrieve
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     put:
       operationId: meta_integrated_system_update
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     patch:
       operationId: meta_integrated_system_partial_update
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     delete:
       operationId: meta_integrated_system_destroy
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/meta/product/:
     get:
       operationId: meta_product_list
       description: Viewset for Product model.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - in: query
-          name: name
-          schema:
-            type: string
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
-        - in: query
-          name: system__slug
-          schema:
-            type: string
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: system__slug
+        schema:
+          type: string
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedProductList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedProductList'
+          description: ''
     post:
       operationId: meta_product_create
       description: Viewset for Product model.
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
         required: true
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
   /api/v0/meta/product/{id}/:
     get:
       operationId: meta_product_retrieve
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     put:
       operationId: meta_product_update
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     patch:
       operationId: meta_product_partial_update
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     delete:
       operationId: meta_product_destroy
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/meta/product/preload/{system_slug}/{sku}/:
     get:
       operationId: meta_product_preload_retrieve
-      description:
-        Pre-loads the product metadata for a given SKU, even if the SKU
+      description: Pre-loads the product metadata for a given SKU, even if the SKU
         doesn't exist yet.
       parameters:
-        - in: path
-          name: sku
-          schema:
-            type: string
-            pattern: ^[^/]+$
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-            pattern: ^[^/]+$
-          required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
   /api/v0/payments/baskets/:
     get:
       operationId: payments_baskets_list
       description: Retrives the current user's baskets, one per system.
       parameters:
-        - in: query
-          name: integrated_system
-          schema:
-            type: integer
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - in: query
+        name: integrated_system
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedBasketWithProductList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedBasketWithProductList'
+          description: ''
   /api/v0/payments/baskets/{id}/:
     get:
       operationId: payments_baskets_retrieve
       description: Retrieve a basket for the current user.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/add_discount/{system_slug}/:
     post:
       operationId: payments_baskets_add_discount_create
-      description:
-        Creates or updates a basket for the current user, adding the discount
+      description: Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
-        - in: query
-          name: discount_code
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: query
+        name: discount_code
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/clear/{system_slug}/:
     delete:
       operationId: payments_baskets_clear_destroy
       description: Clears the basket for the current user.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "204":
+        '204':
           description: No response body
-  /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/:
+  /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/:
     post:
       operationId: payments_baskets_create_from_product_create
-      description:
-        Creates or updates a basket for the current user, adding the selected
+      description: Creates or updates a basket for the current user, adding the selected
         product.
       parameters:
-        - in: path
-          name: discount_code
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: sku
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
+<<<<<<< HEAD
 <<<<<<< HEAD
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
@@ -473,6 +466,33 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateBasketWithProductsRequest'
         required: true
+=======
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
+  /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/:
+    post:
+      operationId: payments_baskets_create_from_product_create_2
+      description: Creates or updates a basket for the current user, adding the selected
+        product.
+      parameters:
+      - in: path
+        name: discount_code
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
+      tags:
+      - payments
+>>>>>>> b889362 (updating openapi spec)
       responses:
         '200':
           content:
@@ -480,123 +500,125 @@ paths:
               schema:
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
+<<<<<<< HEAD
 =======
                 $ref: "#/components/schemas/BasketWithProduct"
           description: ""
 >>>>>>> 27bdec7 (Adding base stuff for product add with discount)
+=======
+>>>>>>> b889362 (updating openapi spec)
   /api/v0/payments/baskets/for_system/{system_slug}/:
     get:
       operationId: payments_baskets_for_system_retrieve
       description: Returns or creates a basket for the current user and system.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/checkout/{system_slug}/:
     post:
       operationId: payments_checkout_create
-      description:
-        Generates and returns the form payload for the current basket for
+      description: Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CyberSourceCheckout"
-          description: ""
+                $ref: '#/components/schemas/CyberSourceCheckout'
+          description: ''
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create
       description: Create a discount.
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Discount"
-          description: ""
+                $ref: '#/components/schemas/Discount'
+          description: ''
   /api/v0/payments/orders/history/:
     get:
       operationId: payments_orders_history_list
       description: Retrives the current user's completed orders.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedOrderHistoryList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedOrderHistoryList'
+          description: ''
   /api/v0/payments/orders/history/{id}/:
     get:
       operationId: payments_orders_history_retrieve
       description: Retrieve a completed order for the current user.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrderHistory"
-          description: ""
+                $ref: '#/components/schemas/OrderHistory'
+          description: ''
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
       description: User retrieve and update viewsets for the current user
       tags:
-        - users
+      - users
       security:
-        - {}
+      - {}
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
-          description: ""
+                $ref: '#/components/schemas/User'
+          description: ''
 components:
   schemas:
     BasketItemWithProduct:
@@ -604,7 +626,7 @@ components:
       description: Basket item model serializer with product information
       properties:
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
         id:
           type: integer
           readOnly: true
@@ -628,14 +650,14 @@ components:
           minimum: 0
         discount_applied:
           allOf:
-            - $ref: "#/components/schemas/SimpleDiscount"
+          - $ref: '#/components/schemas/SimpleDiscount'
           readOnly: true
       required:
-        - discount_applied
-        - discounted_price
-        - id
-        - price
-        - product
+      - discount_applied
+      - discounted_price
+      - id
+      - price
+      - product
     BasketWithProduct:
       type: object
       description: Basket model serializer with items and products
@@ -646,11 +668,11 @@ components:
         user:
           type: integer
         integrated_system:
-          $ref: "#/components/schemas/IntegratedSystem"
+          $ref: '#/components/schemas/IntegratedSystem'
         basket_items:
           type: array
           items:
-            $ref: "#/components/schemas/BasketItemWithProduct"
+            $ref: '#/components/schemas/BasketItemWithProduct'
         subtotal:
           type: number
           format: double
@@ -662,21 +684,21 @@ components:
           description: Get the tax for the basket
           readOnly: true
         tax_rate:
-          $ref: "#/components/schemas/TaxRate"
+          $ref: '#/components/schemas/TaxRate'
         total_price:
           type: number
           format: double
           description: Get the total price for the basket
           readOnly: true
       required:
-        - basket_items
-        - id
-        - integrated_system
-        - subtotal
-        - tax
-        - tax_rate
-        - total_price
-        - user
+      - basket_items
+      - id
+      - integrated_system
+      - subtotal
+      - tax
+      - tax_rate
+      - total_price
+      - user
     Company:
       type: object
       description: Serializer for companies.
@@ -688,259 +710,259 @@ components:
           type: string
           maxLength: 255
       required:
-        - id
-        - name
+      - id
+      - name
     CountryCodeEnum:
       enum:
-        - AF
-        - AX
-        - AL
-        - DZ
-        - AS
-        - AD
-        - AO
-        - AI
-        - AQ
-        - AG
-        - AR
-        - AM
-        - AW
-        - AU
-        - AT
-        - AZ
-        - BS
-        - BH
-        - BD
-        - BB
-        - BY
-        - BE
-        - BZ
-        - BJ
-        - BM
-        - BT
-        - BO
-        - BQ
-        - BA
-        - BW
-        - BV
-        - BR
-        - IO
-        - BN
-        - BG
-        - BF
-        - BI
-        - CV
-        - KH
-        - CM
-        - CA
-        - KY
-        - CF
-        - TD
-        - CL
-        - CN
-        - CX
-        - CC
-        - CO
-        - KM
-        - CG
-        - CD
-        - CK
-        - CR
-        - CI
-        - HR
-        - CU
-        - CW
-        - CY
-        - CZ
-        - DK
-        - DJ
-        - DM
-        - DO
-        - EC
-        - EG
-        - SV
-        - GQ
-        - ER
-        - EE
-        - SZ
-        - ET
-        - FK
-        - FO
-        - FJ
-        - FI
-        - FR
-        - GF
-        - PF
-        - TF
-        - GA
-        - GM
-        - GE
-        - DE
-        - GH
-        - GI
-        - GR
-        - GL
-        - GD
-        - GP
-        - GU
-        - GT
-        - GG
-        - GN
-        - GW
-        - GY
-        - HT
-        - HM
-        - VA
-        - HN
-        - HK
-        - HU
-        - IS
-        - IN
-        - ID
-        - IR
-        - IQ
-        - IE
-        - IM
-        - IL
-        - IT
-        - JM
-        - JP
-        - JE
-        - JO
-        - KZ
-        - KE
-        - KI
-        - KW
-        - KG
-        - LA
-        - LV
-        - LB
-        - LS
-        - LR
-        - LY
-        - LI
-        - LT
-        - LU
-        - MO
-        - MG
-        - MW
-        - MY
-        - MV
-        - ML
-        - MT
-        - MH
-        - MQ
-        - MR
-        - MU
-        - YT
-        - MX
-        - FM
-        - MD
-        - MC
-        - MN
-        - ME
-        - MS
-        - MA
-        - MZ
-        - MM
-        - NA
-        - NR
-        - NP
-        - NL
-        - NC
-        - NZ
-        - NI
-        - NE
-        - NG
-        - NU
-        - NF
-        - KP
-        - MK
-        - MP
-        - "NO"
-        - OM
-        - PK
-        - PW
-        - PS
-        - PA
-        - PG
-        - PY
-        - PE
-        - PH
-        - PN
-        - PL
-        - PT
-        - PR
-        - QA
-        - RE
-        - RO
-        - RU
-        - RW
-        - BL
-        - SH
-        - KN
-        - LC
-        - MF
-        - PM
-        - VC
-        - WS
-        - SM
-        - ST
-        - SA
-        - SN
-        - RS
-        - SC
-        - SL
-        - SG
-        - SX
-        - SK
-        - SI
-        - SB
-        - SO
-        - ZA
-        - GS
-        - KR
-        - SS
-        - ES
-        - LK
-        - SD
-        - SR
-        - SJ
-        - SE
-        - CH
-        - SY
-        - TW
-        - TJ
-        - TZ
-        - TH
-        - TL
-        - TG
-        - TK
-        - TO
-        - TT
-        - TN
-        - TR
-        - TM
-        - TC
-        - TV
-        - UG
-        - UA
-        - AE
-        - GB
-        - UM
-        - US
-        - UY
-        - UZ
-        - VU
-        - VE
-        - VN
-        - VG
-        - VI
-        - WF
-        - EH
-        - YE
-        - ZM
-        - ZW
+      - AF
+      - AX
+      - AL
+      - DZ
+      - AS
+      - AD
+      - AO
+      - AI
+      - AQ
+      - AG
+      - AR
+      - AM
+      - AW
+      - AU
+      - AT
+      - AZ
+      - BS
+      - BH
+      - BD
+      - BB
+      - BY
+      - BE
+      - BZ
+      - BJ
+      - BM
+      - BT
+      - BO
+      - BQ
+      - BA
+      - BW
+      - BV
+      - BR
+      - IO
+      - BN
+      - BG
+      - BF
+      - BI
+      - CV
+      - KH
+      - CM
+      - CA
+      - KY
+      - CF
+      - TD
+      - CL
+      - CN
+      - CX
+      - CC
+      - CO
+      - KM
+      - CG
+      - CD
+      - CK
+      - CR
+      - CI
+      - HR
+      - CU
+      - CW
+      - CY
+      - CZ
+      - DK
+      - DJ
+      - DM
+      - DO
+      - EC
+      - EG
+      - SV
+      - GQ
+      - ER
+      - EE
+      - SZ
+      - ET
+      - FK
+      - FO
+      - FJ
+      - FI
+      - FR
+      - GF
+      - PF
+      - TF
+      - GA
+      - GM
+      - GE
+      - DE
+      - GH
+      - GI
+      - GR
+      - GL
+      - GD
+      - GP
+      - GU
+      - GT
+      - GG
+      - GN
+      - GW
+      - GY
+      - HT
+      - HM
+      - VA
+      - HN
+      - HK
+      - HU
+      - IS
+      - IN
+      - ID
+      - IR
+      - IQ
+      - IE
+      - IM
+      - IL
+      - IT
+      - JM
+      - JP
+      - JE
+      - JO
+      - KZ
+      - KE
+      - KI
+      - KW
+      - KG
+      - LA
+      - LV
+      - LB
+      - LS
+      - LR
+      - LY
+      - LI
+      - LT
+      - LU
+      - MO
+      - MG
+      - MW
+      - MY
+      - MV
+      - ML
+      - MT
+      - MH
+      - MQ
+      - MR
+      - MU
+      - YT
+      - MX
+      - FM
+      - MD
+      - MC
+      - MN
+      - ME
+      - MS
+      - MA
+      - MZ
+      - MM
+      - NA
+      - NR
+      - NP
+      - NL
+      - NC
+      - NZ
+      - NI
+      - NE
+      - NG
+      - NU
+      - NF
+      - KP
+      - MK
+      - MP
+      - 'NO'
+      - OM
+      - PK
+      - PW
+      - PS
+      - PA
+      - PG
+      - PY
+      - PE
+      - PH
+      - PN
+      - PL
+      - PT
+      - PR
+      - QA
+      - RE
+      - RO
+      - RU
+      - RW
+      - BL
+      - SH
+      - KN
+      - LC
+      - MF
+      - PM
+      - VC
+      - WS
+      - SM
+      - ST
+      - SA
+      - SN
+      - RS
+      - SC
+      - SL
+      - SG
+      - SX
+      - SK
+      - SI
+      - SB
+      - SO
+      - ZA
+      - GS
+      - KR
+      - SS
+      - ES
+      - LK
+      - SD
+      - SR
+      - SJ
+      - SE
+      - CH
+      - SY
+      - TW
+      - TJ
+      - TZ
+      - TH
+      - TL
+      - TG
+      - TK
+      - TO
+      - TT
+      - TN
+      - TR
+      - TM
+      - TC
+      - TV
+      - UG
+      - UA
+      - AE
+      - GB
+      - UM
+      - US
+      - UY
+      - UZ
+      - VU
+      - VE
+      - VN
+      - VG
+      - VI
+      - WF
+      - EH
+      - YE
+      - ZM
+      - ZW
       type: string
       description: |-
         * `AF` - Afghanistan
@@ -1194,6 +1216,9 @@ components:
         * `ZW` - Zimbabwe
       x-enum-descriptions:
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> b889362 (updating openapi spec)
       - Afghanistan
       - Åland Islands
       - Albania
@@ -1443,6 +1468,7 @@ components:
       - Yemen
       - Zambia
       - Zimbabwe
+<<<<<<< HEAD
     CreateBasketWithProductsRequest:
       type: object
       description: Serializer for creating a basket with products. (For OpenAPI spec.)
@@ -1728,10 +1754,11 @@ components:
         - Zambia
         - Zimbabwe
 >>>>>>> 27bdec7 (Adding base stuff for product add with discount)
+=======
+>>>>>>> b889362 (updating openapi spec)
     CyberSourceCheckout:
       type: object
-      description:
-        Really basic serializer for the payload that we need to send to
+      description: Really basic serializer for the payload that we need to send to
         CyberSource.
       properties:
         payload:
@@ -1742,9 +1769,9 @@ components:
         method:
           type: string
       required:
-        - method
-        - payload
-        - url
+      - method
+      - payload
+      - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -1762,8 +1789,8 @@ components:
         payment_type:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/PaymentTypeEnum"
-            - $ref: "#/components/schemas/NullEnum"
+          - $ref: '#/components/schemas/PaymentTypeEnum'
+          - $ref: '#/components/schemas/NullEnum'
         max_redemptions:
           type: integer
           maximum: 2147483647
@@ -1773,48 +1800,46 @@ components:
           type: string
           format: date-time
           nullable: true
-          description:
-            If set, this discount code will not be redeemable before this
+          description: If set, this discount code will not be redeemable before this
             date.
         expiration_date:
           type: string
           format: date-time
           nullable: true
-          description:
-            If set, this discount code will not be redeemable after this
+          description: If set, this discount code will not be redeemable after this
             date.
         integrated_system:
-          $ref: "#/components/schemas/IntegratedSystem"
+          $ref: '#/components/schemas/IntegratedSystem'
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
         assigned_users:
           type: array
           items:
-            $ref: "#/components/schemas/User"
+            $ref: '#/components/schemas/User'
         company:
-          $ref: "#/components/schemas/Company"
+          $ref: '#/components/schemas/Company'
       required:
-        - amount
-        - assigned_users
-        - company
-        - discount_code
-        - id
-        - integrated_system
-        - product
+      - amount
+      - assigned_users
+      - company
+      - discount_code
+      - id
+      - integrated_system
+      - product
     DiscountTypeEnum:
       enum:
-        - percent-off
-        - dollars-off
-        - fixed-price
+      - percent-off
+      - dollars-off
+      - fixed-price
       type: string
       description: |-
         * `percent-off` - percent-off
         * `dollars-off` - dollars-off
         * `fixed-price` - fixed-price
       x-enum-descriptions:
-        - percent-off
-        - dollars-off
-        - fixed-price
+      - percent-off
+      - dollars-off
+      - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1832,8 +1857,8 @@ components:
         description:
           type: string
       required:
-        - id
-        - name
+      - id
+      - name
     IntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1849,7 +1874,7 @@ components:
         description:
           type: string
       required:
-        - name
+      - name
     Line:
       type: object
       description: Serializes a line item for an order.
@@ -1874,17 +1899,17 @@ components:
           format: decimal
           pattern: ^-?\d{0,7}(?:\.\d{0,2})?$
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
       required:
-        - id
-        - item_description
-        - product
-        - quantity
-        - total_price
-        - unit_price
+      - id
+      - item_description
+      - product
+      - quantity
+      - total_price
+      - unit_price
     NullEnum:
       enum:
-        - null
+      - null
     OrderHistory:
       type: object
       description: Serializer for order history.
@@ -1893,7 +1918,7 @@ components:
           type: integer
           readOnly: true
         state:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         reference_number:
           type: string
           maxLength: 255
@@ -1906,7 +1931,7 @@ components:
         lines:
           type: array
           items:
-            $ref: "#/components/schemas/Line"
+            $ref: '#/components/schemas/Line'
         created_on:
           type: string
           format: date-time
@@ -1916,17 +1941,17 @@ components:
           format: date-time
           readOnly: true
       required:
-        - created_on
-        - id
-        - lines
-        - purchaser
-        - total_price_paid
-        - updated_on
+      - created_on
+      - id
+      - lines
+      - purchaser
+      - total_price_paid
+      - updated_on
     PaginatedBasketWithProductList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1944,12 +1969,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/BasketWithProduct"
+            $ref: '#/components/schemas/BasketWithProduct'
     PaginatedIntegratedSystemList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1967,12 +1992,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/IntegratedSystem"
+            $ref: '#/components/schemas/IntegratedSystem'
     PaginatedOrderHistoryList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1990,12 +2015,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/OrderHistory"
+            $ref: '#/components/schemas/OrderHistory'
     PaginatedProductList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -2013,7 +2038,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Product"
+            $ref: '#/components/schemas/Product'
     PatchedIntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -2059,19 +2084,18 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
     PaymentTypeEnum:
       enum:
-        - marketing
-        - sales
-        - financial-assistance
-        - customer-support
-        - staff
-        - legacy
-        - credit_card
-        - purchase_order
+      - marketing
+      - sales
+      - financial-assistance
+      - customer-support
+      - staff
+      - legacy
+      - credit_card
+      - purchase_order
       type: string
       description: |-
         * `marketing` - marketing
@@ -2083,14 +2107,14 @@ components:
         * `credit_card` - credit_card
         * `purchase_order` - purchase_order
       x-enum-descriptions:
-        - marketing
-        - sales
-        - financial-assistance
-        - customer-support
-        - staff
-        - legacy
-        - credit_card
-        - purchase_order
+      - marketing
+      - sales
+      - financial-assistance
+      - customer-support
+      - staff
+      - legacy
+      - credit_card
+      - purchase_order
     Product:
       type: object
       description: Serializer for Product model.
@@ -2125,17 +2149,16 @@ components:
           readOnly: true
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
       required:
-        - deleted_by_cascade
-        - description
-        - id
-        - name
-        - price
-        - sku
-        - system
+      - deleted_by_cascade
+      - description
+      - id
+      - name
+      - price
+      - sku
+      - system
     ProductRequest:
       type: object
       description: Serializer for Product model.
@@ -2167,15 +2190,14 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
       required:
-        - description
-        - name
-        - price
-        - sku
-        - system
+      - description
+      - name
+      - price
+      - sku
+      - system
     SimpleDiscount:
       type: object
       description: Simpler serializer for discounts.
@@ -2191,7 +2213,7 @@ components:
           format: decimal
           pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
         discount_type:
-          $ref: "#/components/schemas/DiscountTypeEnum"
+          $ref: '#/components/schemas/DiscountTypeEnum'
         formatted_discount_amount:
           type: string
           description: |-
@@ -2200,20 +2222,20 @@ components:
             This quantizes percent discounts to whole numbers. This is probably fine.
           readOnly: true
       required:
-        - amount
-        - discount_code
-        - discount_type
-        - formatted_discount_amount
-        - id
+      - amount
+      - discount_code
+      - discount_type
+      - formatted_discount_amount
+      - id
     StateEnum:
       enum:
-        - pending
-        - fulfilled
-        - canceled
-        - refunded
-        - declined
-        - errored
-        - review
+      - pending
+      - fulfilled
+      - canceled
+      - refunded
+      - declined
+      - errored
+      - review
       type: string
       description: |-
         * `pending` - Pending
@@ -2224,13 +2246,13 @@ components:
         * `errored` - Errored
         * `review` - Review
       x-enum-descriptions:
-        - Pending
-        - Fulfilled
-        - Canceled
-        - Refunded
-        - Declined
-        - Errored
-        - Review
+      - Pending
+      - Fulfilled
+      - Canceled
+      - Refunded
+      - Declined
+      - Errored
+      - Review
     TaxRate:
       type: object
       description: TaxRate model serializer
@@ -2239,7 +2261,7 @@ components:
           type: integer
           readOnly: true
         country_code:
-          $ref: "#/components/schemas/CountryCodeEnum"
+          $ref: '#/components/schemas/CountryCodeEnum'
         tax_rate:
           type: string
           format: decimal
@@ -2248,8 +2270,8 @@ components:
           type: string
           maxLength: 100
       required:
-        - country_code
-        - id
+      - country_code
+      - id
     User:
       type: object
       description: Serializer for User model.
@@ -2259,8 +2281,7 @@ components:
           readOnly: true
         username:
           type: string
-          description:
-            Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
@@ -2276,5 +2297,5 @@ components:
           type: string
           maxLength: 150
       required:
-        - id
-        - username
+      - id
+      - username

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9,644 +9,616 @@ paths:
       operationId: meta_integrated_system_list
       description: Viewset for IntegratedSystem model.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedIntegratedSystemList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedIntegratedSystemList"
+          description: ""
     post:
       operationId: meta_integrated_system_create
       description: Viewset for IntegratedSystem model.
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
         required: true
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
   /api/v0/meta/integrated_system/{id}/:
     get:
       operationId: meta_integrated_system_retrieve
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     put:
       operationId: meta_integrated_system_update
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
         required: true
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     patch:
       operationId: meta_integrated_system_partial_update
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     delete:
       operationId: meta_integrated_system_destroy
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/meta/product/:
     get:
       operationId: meta_product_list
       description: Viewset for Product model.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: system__slug
-        schema:
-          type: string
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - in: query
+          name: name
+          schema:
+            type: string
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
+        - in: query
+          name: system__slug
+          schema:
+            type: string
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedProductList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedProductList"
+          description: ""
     post:
       operationId: meta_product_create
       description: Viewset for Product model.
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
         required: true
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
   /api/v0/meta/product/{id}/:
     get:
       operationId: meta_product_retrieve
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     put:
       operationId: meta_product_update
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
         required: true
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     patch:
       operationId: meta_product_partial_update
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     delete:
       operationId: meta_product_destroy
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/meta/product/preload/{system_slug}/{sku}/:
     get:
       operationId: meta_product_preload_retrieve
-      description: Pre-loads the product metadata for a given SKU, even if the SKU
+      description:
+        Pre-loads the product metadata for a given SKU, even if the SKU
         doesn't exist yet.
       parameters:
-      - in: path
-        name: sku
-        schema:
-          type: string
-          pattern: ^[^/]+$
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-          pattern: ^[^/]+$
-        required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+            pattern: ^[^/]+$
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+            pattern: ^[^/]+$
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
   /api/v0/payments/baskets/:
     get:
       operationId: payments_baskets_list
       description: Retrives the current user's baskets, one per system.
       parameters:
-      - in: query
-        name: integrated_system
-        schema:
-          type: integer
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - in: query
+          name: integrated_system
+          schema:
+            type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedBasketWithProductList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedBasketWithProductList"
+          description: ""
   /api/v0/payments/baskets/{id}/:
     get:
       operationId: payments_baskets_retrieve
       description: Retrieve a basket for the current user.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/add_discount/{system_slug}/:
     post:
       operationId: payments_baskets_add_discount_create
-      description: Creates or updates a basket for the current user, adding the discount
+      description:
+        Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
-      - in: query
-        name: discount_code
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: query
+          name: discount_code
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/clear/{system_slug}/:
     delete:
       operationId: payments_baskets_clear_destroy
       description: Clears the basket for the current user.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/:
     post:
       operationId: payments_baskets_create_from_product_create
-      description: Creates or updates a basket for the current user, adding the selected
+      description:
+        Creates or updates a basket for the current user, adding the selected
         product.
       parameters:
-      - in: path
-        name: sku
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
+  /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/:
+    post:
+      operationId: create_basket_from_product_with_discount
+      description:
+        Creates or updates a basket for the current user, adding the selected
+        product and discount.
+      parameters:
+        - in: path
+          name: discount_code
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
+      tags:
+        - payments
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/create_with_products/:
     post:
       operationId: payments_baskets_create_with_products_create
-      description: Creates or updates a basket for the current user, adding the selected
+      description:
+        Creates or updates a basket for the current user, adding the selected
         product.
       tags:
-      - payments
+        - payments
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
+              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
+              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
+              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
         required: true
-=======
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
-=======
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
-=======
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
->>>>>>> 941ea5f (update schema)
-  /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/:
-    post:
-      operationId: create_basket_from_product_with_discount
-      description: Creates or updates a basket for the current user, adding the selected
-        product and discount.
-      parameters:
-      - in: path
-        name: discount_code
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: sku
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
-      tags:
-<<<<<<< HEAD
-<<<<<<< HEAD
-      - payments
->>>>>>> b889362 (updating openapi spec)
-=======
-        - payments
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
-=======
-      - payments
->>>>>>> 941ea5f (update schema)
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-<<<<<<< HEAD
-<<<<<<< HEAD
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
-<<<<<<< HEAD
-=======
                 $ref: "#/components/schemas/BasketWithProduct"
           description: ""
->>>>>>> 27bdec7 (Adding base stuff for product add with discount)
-=======
->>>>>>> b889362 (updating openapi spec)
-=======
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
-=======
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
->>>>>>> 941ea5f (update schema)
   /api/v0/payments/baskets/for_system/{system_slug}/:
     get:
       operationId: payments_baskets_for_system_retrieve
       description: Returns or creates a basket for the current user and system.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/checkout/{system_slug}/:
     post:
       operationId: payments_checkout_create
-      description: Generates and returns the form payload for the current basket for
+      description:
+        Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CyberSourceCheckout'
-          description: ''
+                $ref: "#/components/schemas/CyberSourceCheckout"
+          description: ""
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create
       description: Create a discount.
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Discount'
-          description: ''
+                $ref: "#/components/schemas/Discount"
+          description: ""
   /api/v0/payments/orders/history/:
     get:
       operationId: payments_orders_history_list
       description: Retrives the current user's completed orders.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedOrderHistoryList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedOrderHistoryList"
+          description: ""
   /api/v0/payments/orders/history/{id}/:
     get:
       operationId: payments_orders_history_retrieve
       description: Retrieve a completed order for the current user.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderHistory'
-          description: ''
+                $ref: "#/components/schemas/OrderHistory"
+          description: ""
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
       description: User retrieve and update viewsets for the current user
       tags:
-      - users
+        - users
       security:
-      - {}
+        - {}
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
-          description: ''
+                $ref: "#/components/schemas/User"
+          description: ""
 components:
   schemas:
     BasketItemWithProduct:
@@ -654,7 +626,7 @@ components:
       description: Basket item model serializer with product information
       properties:
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
         id:
           type: integer
           readOnly: true
@@ -678,14 +650,14 @@ components:
           minimum: 0
         discount_applied:
           allOf:
-          - $ref: '#/components/schemas/SimpleDiscount'
+            - $ref: "#/components/schemas/SimpleDiscount"
           readOnly: true
       required:
-      - discount_applied
-      - discounted_price
-      - id
-      - price
-      - product
+        - discount_applied
+        - discounted_price
+        - id
+        - price
+        - product
     BasketWithProduct:
       type: object
       description: Basket model serializer with items and products
@@ -696,11 +668,11 @@ components:
         user:
           type: integer
         integrated_system:
-          $ref: '#/components/schemas/IntegratedSystem'
+          $ref: "#/components/schemas/IntegratedSystem"
         basket_items:
           type: array
           items:
-            $ref: '#/components/schemas/BasketItemWithProduct'
+            $ref: "#/components/schemas/BasketItemWithProduct"
         subtotal:
           type: number
           format: double
@@ -712,21 +684,21 @@ components:
           description: Get the tax for the basket
           readOnly: true
         tax_rate:
-          $ref: '#/components/schemas/TaxRate'
+          $ref: "#/components/schemas/TaxRate"
         total_price:
           type: number
           format: double
           description: Get the total price for the basket
           readOnly: true
       required:
-      - basket_items
-      - id
-      - integrated_system
-      - subtotal
-      - tax
-      - tax_rate
-      - total_price
-      - user
+        - basket_items
+        - id
+        - integrated_system
+        - subtotal
+        - tax
+        - tax_rate
+        - total_price
+        - user
     Company:
       type: object
       description: Serializer for companies.
@@ -738,259 +710,259 @@ components:
           type: string
           maxLength: 255
       required:
-      - id
-      - name
+        - id
+        - name
     CountryCodeEnum:
       enum:
-      - AF
-      - AX
-      - AL
-      - DZ
-      - AS
-      - AD
-      - AO
-      - AI
-      - AQ
-      - AG
-      - AR
-      - AM
-      - AW
-      - AU
-      - AT
-      - AZ
-      - BS
-      - BH
-      - BD
-      - BB
-      - BY
-      - BE
-      - BZ
-      - BJ
-      - BM
-      - BT
-      - BO
-      - BQ
-      - BA
-      - BW
-      - BV
-      - BR
-      - IO
-      - BN
-      - BG
-      - BF
-      - BI
-      - CV
-      - KH
-      - CM
-      - CA
-      - KY
-      - CF
-      - TD
-      - CL
-      - CN
-      - CX
-      - CC
-      - CO
-      - KM
-      - CG
-      - CD
-      - CK
-      - CR
-      - CI
-      - HR
-      - CU
-      - CW
-      - CY
-      - CZ
-      - DK
-      - DJ
-      - DM
-      - DO
-      - EC
-      - EG
-      - SV
-      - GQ
-      - ER
-      - EE
-      - SZ
-      - ET
-      - FK
-      - FO
-      - FJ
-      - FI
-      - FR
-      - GF
-      - PF
-      - TF
-      - GA
-      - GM
-      - GE
-      - DE
-      - GH
-      - GI
-      - GR
-      - GL
-      - GD
-      - GP
-      - GU
-      - GT
-      - GG
-      - GN
-      - GW
-      - GY
-      - HT
-      - HM
-      - VA
-      - HN
-      - HK
-      - HU
-      - IS
-      - IN
-      - ID
-      - IR
-      - IQ
-      - IE
-      - IM
-      - IL
-      - IT
-      - JM
-      - JP
-      - JE
-      - JO
-      - KZ
-      - KE
-      - KI
-      - KW
-      - KG
-      - LA
-      - LV
-      - LB
-      - LS
-      - LR
-      - LY
-      - LI
-      - LT
-      - LU
-      - MO
-      - MG
-      - MW
-      - MY
-      - MV
-      - ML
-      - MT
-      - MH
-      - MQ
-      - MR
-      - MU
-      - YT
-      - MX
-      - FM
-      - MD
-      - MC
-      - MN
-      - ME
-      - MS
-      - MA
-      - MZ
-      - MM
-      - NA
-      - NR
-      - NP
-      - NL
-      - NC
-      - NZ
-      - NI
-      - NE
-      - NG
-      - NU
-      - NF
-      - KP
-      - MK
-      - MP
-      - 'NO'
-      - OM
-      - PK
-      - PW
-      - PS
-      - PA
-      - PG
-      - PY
-      - PE
-      - PH
-      - PN
-      - PL
-      - PT
-      - PR
-      - QA
-      - RE
-      - RO
-      - RU
-      - RW
-      - BL
-      - SH
-      - KN
-      - LC
-      - MF
-      - PM
-      - VC
-      - WS
-      - SM
-      - ST
-      - SA
-      - SN
-      - RS
-      - SC
-      - SL
-      - SG
-      - SX
-      - SK
-      - SI
-      - SB
-      - SO
-      - ZA
-      - GS
-      - KR
-      - SS
-      - ES
-      - LK
-      - SD
-      - SR
-      - SJ
-      - SE
-      - CH
-      - SY
-      - TW
-      - TJ
-      - TZ
-      - TH
-      - TL
-      - TG
-      - TK
-      - TO
-      - TT
-      - TN
-      - TR
-      - TM
-      - TC
-      - TV
-      - UG
-      - UA
-      - AE
-      - GB
-      - UM
-      - US
-      - UY
-      - UZ
-      - VU
-      - VE
-      - VN
-      - VG
-      - VI
-      - WF
-      - EH
-      - YE
-      - ZM
-      - ZW
+        - AF
+        - AX
+        - AL
+        - DZ
+        - AS
+        - AD
+        - AO
+        - AI
+        - AQ
+        - AG
+        - AR
+        - AM
+        - AW
+        - AU
+        - AT
+        - AZ
+        - BS
+        - BH
+        - BD
+        - BB
+        - BY
+        - BE
+        - BZ
+        - BJ
+        - BM
+        - BT
+        - BO
+        - BQ
+        - BA
+        - BW
+        - BV
+        - BR
+        - IO
+        - BN
+        - BG
+        - BF
+        - BI
+        - CV
+        - KH
+        - CM
+        - CA
+        - KY
+        - CF
+        - TD
+        - CL
+        - CN
+        - CX
+        - CC
+        - CO
+        - KM
+        - CG
+        - CD
+        - CK
+        - CR
+        - CI
+        - HR
+        - CU
+        - CW
+        - CY
+        - CZ
+        - DK
+        - DJ
+        - DM
+        - DO
+        - EC
+        - EG
+        - SV
+        - GQ
+        - ER
+        - EE
+        - SZ
+        - ET
+        - FK
+        - FO
+        - FJ
+        - FI
+        - FR
+        - GF
+        - PF
+        - TF
+        - GA
+        - GM
+        - GE
+        - DE
+        - GH
+        - GI
+        - GR
+        - GL
+        - GD
+        - GP
+        - GU
+        - GT
+        - GG
+        - GN
+        - GW
+        - GY
+        - HT
+        - HM
+        - VA
+        - HN
+        - HK
+        - HU
+        - IS
+        - IN
+        - ID
+        - IR
+        - IQ
+        - IE
+        - IM
+        - IL
+        - IT
+        - JM
+        - JP
+        - JE
+        - JO
+        - KZ
+        - KE
+        - KI
+        - KW
+        - KG
+        - LA
+        - LV
+        - LB
+        - LS
+        - LR
+        - LY
+        - LI
+        - LT
+        - LU
+        - MO
+        - MG
+        - MW
+        - MY
+        - MV
+        - ML
+        - MT
+        - MH
+        - MQ
+        - MR
+        - MU
+        - YT
+        - MX
+        - FM
+        - MD
+        - MC
+        - MN
+        - ME
+        - MS
+        - MA
+        - MZ
+        - MM
+        - NA
+        - NR
+        - NP
+        - NL
+        - NC
+        - NZ
+        - NI
+        - NE
+        - NG
+        - NU
+        - NF
+        - KP
+        - MK
+        - MP
+        - "NO"
+        - OM
+        - PK
+        - PW
+        - PS
+        - PA
+        - PG
+        - PY
+        - PE
+        - PH
+        - PN
+        - PL
+        - PT
+        - PR
+        - QA
+        - RE
+        - RO
+        - RU
+        - RW
+        - BL
+        - SH
+        - KN
+        - LC
+        - MF
+        - PM
+        - VC
+        - WS
+        - SM
+        - ST
+        - SA
+        - SN
+        - RS
+        - SC
+        - SL
+        - SG
+        - SX
+        - SK
+        - SI
+        - SB
+        - SO
+        - ZA
+        - GS
+        - KR
+        - SS
+        - ES
+        - LK
+        - SD
+        - SR
+        - SJ
+        - SE
+        - CH
+        - SY
+        - TW
+        - TJ
+        - TZ
+        - TH
+        - TL
+        - TG
+        - TK
+        - TO
+        - TT
+        - TN
+        - TR
+        - TM
+        - TC
+        - TV
+        - UG
+        - UA
+        - AE
+        - GB
+        - UM
+        - US
+        - UY
+        - UZ
+        - VU
+        - VE
+        - VN
+        - VG
+        - VI
+        - WF
+        - EH
+        - YE
+        - ZM
+        - ZW
       type: string
       description: |-
         * `AF` - Afghanistan
@@ -1243,302 +1215,6 @@ components:
         * `ZM` - Zambia
         * `ZW` - Zimbabwe
       x-enum-descriptions:
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> b889362 (updating openapi spec)
-=======
->>>>>>> 941ea5f (update schema)
-      - Afghanistan
-      - Åland Islands
-      - Albania
-      - Algeria
-      - American Samoa
-      - Andorra
-      - Angola
-      - Anguilla
-      - Antarctica
-      - Antigua and Barbuda
-      - Argentina
-      - Armenia
-      - Aruba
-      - Australia
-      - Austria
-      - Azerbaijan
-      - Bahamas
-      - Bahrain
-      - Bangladesh
-      - Barbados
-      - Belarus
-      - Belgium
-      - Belize
-      - Benin
-      - Bermuda
-      - Bhutan
-      - Bolivia
-      - Bonaire, Sint Eustatius and Saba
-      - Bosnia and Herzegovina
-      - Botswana
-      - Bouvet Island
-      - Brazil
-      - British Indian Ocean Territory
-      - Brunei
-      - Bulgaria
-      - Burkina Faso
-      - Burundi
-      - Cabo Verde
-      - Cambodia
-      - Cameroon
-      - Canada
-      - Cayman Islands
-      - Central African Republic
-      - Chad
-      - Chile
-      - China
-      - Christmas Island
-      - Cocos (Keeling) Islands
-      - Colombia
-      - Comoros
-      - Congo
-      - Congo (the Democratic Republic of the)
-      - Cook Islands
-      - Costa Rica
-      - Côte d'Ivoire
-      - Croatia
-      - Cuba
-      - Curaçao
-      - Cyprus
-      - Czechia
-      - Denmark
-      - Djibouti
-      - Dominica
-      - Dominican Republic
-      - Ecuador
-      - Egypt
-      - El Salvador
-      - Equatorial Guinea
-      - Eritrea
-      - Estonia
-      - Eswatini
-      - Ethiopia
-      - Falkland Islands (Malvinas)
-      - Faroe Islands
-      - Fiji
-      - Finland
-      - France
-      - French Guiana
-      - French Polynesia
-      - French Southern Territories
-      - Gabon
-      - Gambia
-      - Georgia
-      - Germany
-      - Ghana
-      - Gibraltar
-      - Greece
-      - Greenland
-      - Grenada
-      - Guadeloupe
-      - Guam
-      - Guatemala
-      - Guernsey
-      - Guinea
-      - Guinea-Bissau
-      - Guyana
-      - Haiti
-      - Heard Island and McDonald Islands
-      - Holy See
-      - Honduras
-      - Hong Kong
-      - Hungary
-      - Iceland
-      - India
-      - Indonesia
-      - Iran
-      - Iraq
-      - Ireland
-      - Isle of Man
-      - Israel
-      - Italy
-      - Jamaica
-      - Japan
-      - Jersey
-      - Jordan
-      - Kazakhstan
-      - Kenya
-      - Kiribati
-      - Kuwait
-      - Kyrgyzstan
-      - Laos
-      - Latvia
-      - Lebanon
-      - Lesotho
-      - Liberia
-      - Libya
-      - Liechtenstein
-      - Lithuania
-      - Luxembourg
-      - Macao
-      - Madagascar
-      - Malawi
-      - Malaysia
-      - Maldives
-      - Mali
-      - Malta
-      - Marshall Islands
-      - Martinique
-      - Mauritania
-      - Mauritius
-      - Mayotte
-      - Mexico
-      - Micronesia
-      - Moldova
-      - Monaco
-      - Mongolia
-      - Montenegro
-      - Montserrat
-      - Morocco
-      - Mozambique
-      - Myanmar
-      - Namibia
-      - Nauru
-      - Nepal
-      - Netherlands
-      - New Caledonia
-      - New Zealand
-      - Nicaragua
-      - Niger
-      - Nigeria
-      - Niue
-      - Norfolk Island
-      - North Korea
-      - North Macedonia
-      - Northern Mariana Islands
-      - Norway
-      - Oman
-      - Pakistan
-      - Palau
-      - Palestine, State of
-      - Panama
-      - Papua New Guinea
-      - Paraguay
-      - Peru
-      - Philippines
-      - Pitcairn
-      - Poland
-      - Portugal
-      - Puerto Rico
-      - Qatar
-      - Réunion
-      - Romania
-      - Russia
-      - Rwanda
-      - Saint Barthélemy
-      - Saint Helena, Ascension and Tristan da Cunha
-      - Saint Kitts and Nevis
-      - Saint Lucia
-      - Saint Martin (French part)
-      - Saint Pierre and Miquelon
-      - Saint Vincent and the Grenadines
-      - Samoa
-      - San Marino
-      - Sao Tome and Principe
-      - Saudi Arabia
-      - Senegal
-      - Serbia
-      - Seychelles
-      - Sierra Leone
-      - Singapore
-      - Sint Maarten (Dutch part)
-      - Slovakia
-      - Slovenia
-      - Solomon Islands
-      - Somalia
-      - South Africa
-      - South Georgia and the South Sandwich Islands
-      - South Korea
-      - South Sudan
-      - Spain
-      - Sri Lanka
-      - Sudan
-      - Suriname
-      - Svalbard and Jan Mayen
-      - Sweden
-      - Switzerland
-      - Syria
-      - Taiwan
-      - Tajikistan
-      - Tanzania
-      - Thailand
-      - Timor-Leste
-      - Togo
-      - Tokelau
-      - Tonga
-      - Trinidad and Tobago
-      - Tunisia
-      - Türkiye
-      - Turkmenistan
-      - Turks and Caicos Islands
-      - Tuvalu
-      - Uganda
-      - Ukraine
-      - United Arab Emirates
-      - United Kingdom
-      - United States Minor Outlying Islands
-      - United States of America
-      - Uruguay
-      - Uzbekistan
-      - Vanuatu
-      - Venezuela
-      - Vietnam
-      - Virgin Islands (British)
-      - Virgin Islands (U.S.)
-      - Wallis and Futuna
-      - Western Sahara
-      - Yemen
-      - Zambia
-      - Zimbabwe
-<<<<<<< HEAD
-<<<<<<< HEAD
-    CreateBasketWithProductsRequest:
-      type: object
-      description: Serializer for creating a basket with products. (For OpenAPI spec.)
-      properties:
-        system_slug:
-          type: string
-          minLength: 1
-        skus:
-          type: array
-          items:
-            $ref: '#/components/schemas/CreateBasketWithProductsSkuRequest'
-        checkout:
-          type: boolean
-        discount_code:
-          type: string
-          minLength: 1
-      required:
-      - checkout
-      - discount_code
-      - skus
-      - system_slug
-    CreateBasketWithProductsSkuRequest:
-      type: object
-      description: Defines the schema for a SKU in the CreateBasketWithProductsSerializer.
-      properties:
-        sku:
-          type: string
-          minLength: 1
-        quantity:
-          type: integer
-          minimum: 1
-      required:
-      - quantity
-      - sku
-=======
-=======
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
         - Afghanistan
         - Åland Islands
         - Albania
@@ -1788,17 +1464,44 @@ components:
         - Yemen
         - Zambia
         - Zimbabwe
-<<<<<<< HEAD
->>>>>>> 27bdec7 (Adding base stuff for product add with discount)
-=======
->>>>>>> b889362 (updating openapi spec)
-=======
->>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
-=======
->>>>>>> 941ea5f (update schema)
+    CreateBasketWithProductsRequest:
+      type: object
+      description: Serializer for creating a basket with products. (For OpenAPI spec.)
+      properties:
+        system_slug:
+          type: string
+          minLength: 1
+        skus:
+          type: array
+          items:
+            $ref: "#/components/schemas/CreateBasketWithProductsSkuRequest"
+        checkout:
+          type: boolean
+        discount_code:
+          type: string
+          minLength: 1
+      required:
+        - checkout
+        - discount_code
+        - skus
+        - system_slug
+    CreateBasketWithProductsSkuRequest:
+      type: object
+      description: Defines the schema for a SKU in the CreateBasketWithProductsSerializer.
+      properties:
+        sku:
+          type: string
+          minLength: 1
+        quantity:
+          type: integer
+          minimum: 1
+      required:
+        - quantity
+        - sku
     CyberSourceCheckout:
       type: object
-      description: Really basic serializer for the payload that we need to send to
+      description:
+        Really basic serializer for the payload that we need to send to
         CyberSource.
       properties:
         payload:
@@ -1809,9 +1512,9 @@ components:
         method:
           type: string
       required:
-      - method
-      - payload
-      - url
+        - method
+        - payload
+        - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -1829,8 +1532,8 @@ components:
         payment_type:
           nullable: true
           oneOf:
-          - $ref: '#/components/schemas/PaymentTypeEnum'
-          - $ref: '#/components/schemas/NullEnum'
+            - $ref: "#/components/schemas/PaymentTypeEnum"
+            - $ref: "#/components/schemas/NullEnum"
         max_redemptions:
           type: integer
           maximum: 2147483647
@@ -1840,46 +1543,48 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: If set, this discount code will not be redeemable before this
+          description:
+            If set, this discount code will not be redeemable before this
             date.
         expiration_date:
           type: string
           format: date-time
           nullable: true
-          description: If set, this discount code will not be redeemable after this
+          description:
+            If set, this discount code will not be redeemable after this
             date.
         integrated_system:
-          $ref: '#/components/schemas/IntegratedSystem'
+          $ref: "#/components/schemas/IntegratedSystem"
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
         assigned_users:
           type: array
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         company:
-          $ref: '#/components/schemas/Company'
+          $ref: "#/components/schemas/Company"
       required:
-      - amount
-      - assigned_users
-      - company
-      - discount_code
-      - id
-      - integrated_system
-      - product
+        - amount
+        - assigned_users
+        - company
+        - discount_code
+        - id
+        - integrated_system
+        - product
     DiscountTypeEnum:
       enum:
-      - percent-off
-      - dollars-off
-      - fixed-price
+        - percent-off
+        - dollars-off
+        - fixed-price
       type: string
       description: |-
         * `percent-off` - percent-off
         * `dollars-off` - dollars-off
         * `fixed-price` - fixed-price
       x-enum-descriptions:
-      - percent-off
-      - dollars-off
-      - fixed-price
+        - percent-off
+        - dollars-off
+        - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1897,8 +1602,8 @@ components:
         description:
           type: string
       required:
-      - id
-      - name
+        - id
+        - name
     IntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1914,7 +1619,7 @@ components:
         description:
           type: string
       required:
-      - name
+        - name
     Line:
       type: object
       description: Serializes a line item for an order.
@@ -1939,17 +1644,17 @@ components:
           format: decimal
           pattern: ^-?\d{0,7}(?:\.\d{0,2})?$
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
       required:
-      - id
-      - item_description
-      - product
-      - quantity
-      - total_price
-      - unit_price
+        - id
+        - item_description
+        - product
+        - quantity
+        - total_price
+        - unit_price
     NullEnum:
       enum:
-      - null
+        - null
     OrderHistory:
       type: object
       description: Serializer for order history.
@@ -1958,7 +1663,7 @@ components:
           type: integer
           readOnly: true
         state:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         reference_number:
           type: string
           maxLength: 255
@@ -1971,7 +1676,7 @@ components:
         lines:
           type: array
           items:
-            $ref: '#/components/schemas/Line'
+            $ref: "#/components/schemas/Line"
         created_on:
           type: string
           format: date-time
@@ -1981,17 +1686,17 @@ components:
           format: date-time
           readOnly: true
       required:
-      - created_on
-      - id
-      - lines
-      - purchaser
-      - total_price_paid
-      - updated_on
+        - created_on
+        - id
+        - lines
+        - purchaser
+        - total_price_paid
+        - updated_on
     PaginatedBasketWithProductList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -2009,12 +1714,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/BasketWithProduct'
+            $ref: "#/components/schemas/BasketWithProduct"
     PaginatedIntegratedSystemList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -2032,12 +1737,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/IntegratedSystem'
+            $ref: "#/components/schemas/IntegratedSystem"
     PaginatedOrderHistoryList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -2055,12 +1760,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/OrderHistory'
+            $ref: "#/components/schemas/OrderHistory"
     PaginatedProductList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -2078,7 +1783,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Product'
+            $ref: "#/components/schemas/Product"
     PatchedIntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -2124,18 +1829,19 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
     PaymentTypeEnum:
       enum:
-      - marketing
-      - sales
-      - financial-assistance
-      - customer-support
-      - staff
-      - legacy
-      - credit_card
-      - purchase_order
+        - marketing
+        - sales
+        - financial-assistance
+        - customer-support
+        - staff
+        - legacy
+        - credit_card
+        - purchase_order
       type: string
       description: |-
         * `marketing` - marketing
@@ -2147,14 +1853,14 @@ components:
         * `credit_card` - credit_card
         * `purchase_order` - purchase_order
       x-enum-descriptions:
-      - marketing
-      - sales
-      - financial-assistance
-      - customer-support
-      - staff
-      - legacy
-      - credit_card
-      - purchase_order
+        - marketing
+        - sales
+        - financial-assistance
+        - customer-support
+        - staff
+        - legacy
+        - credit_card
+        - purchase_order
     Product:
       type: object
       description: Serializer for Product model.
@@ -2189,16 +1895,17 @@ components:
           readOnly: true
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
       required:
-      - deleted_by_cascade
-      - description
-      - id
-      - name
-      - price
-      - sku
-      - system
+        - deleted_by_cascade
+        - description
+        - id
+        - name
+        - price
+        - sku
+        - system
     ProductRequest:
       type: object
       description: Serializer for Product model.
@@ -2230,14 +1937,15 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
       required:
-      - description
-      - name
-      - price
-      - sku
-      - system
+        - description
+        - name
+        - price
+        - sku
+        - system
     SimpleDiscount:
       type: object
       description: Simpler serializer for discounts.
@@ -2253,7 +1961,7 @@ components:
           format: decimal
           pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
         discount_type:
-          $ref: '#/components/schemas/DiscountTypeEnum'
+          $ref: "#/components/schemas/DiscountTypeEnum"
         formatted_discount_amount:
           type: string
           description: |-
@@ -2262,20 +1970,20 @@ components:
             This quantizes percent discounts to whole numbers. This is probably fine.
           readOnly: true
       required:
-      - amount
-      - discount_code
-      - discount_type
-      - formatted_discount_amount
-      - id
+        - amount
+        - discount_code
+        - discount_type
+        - formatted_discount_amount
+        - id
     StateEnum:
       enum:
-      - pending
-      - fulfilled
-      - canceled
-      - refunded
-      - declined
-      - errored
-      - review
+        - pending
+        - fulfilled
+        - canceled
+        - refunded
+        - declined
+        - errored
+        - review
       type: string
       description: |-
         * `pending` - Pending
@@ -2286,13 +1994,13 @@ components:
         * `errored` - Errored
         * `review` - Review
       x-enum-descriptions:
-      - Pending
-      - Fulfilled
-      - Canceled
-      - Refunded
-      - Declined
-      - Errored
-      - Review
+        - Pending
+        - Fulfilled
+        - Canceled
+        - Refunded
+        - Declined
+        - Errored
+        - Review
     TaxRate:
       type: object
       description: TaxRate model serializer
@@ -2301,7 +2009,7 @@ components:
           type: integer
           readOnly: true
         country_code:
-          $ref: '#/components/schemas/CountryCodeEnum'
+          $ref: "#/components/schemas/CountryCodeEnum"
         tax_rate:
           type: string
           format: decimal
@@ -2310,8 +2018,8 @@ components:
           type: string
           maxLength: 100
       required:
-      - country_code
-      - id
+        - country_code
+        - id
     User:
       type: object
       description: Serializer for User model.
@@ -2321,7 +2029,8 @@ components:
           readOnly: true
         username:
           type: string
-          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+          description:
+            Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
@@ -2337,5 +2046,5 @@ components:
           type: string
           maxLength: 150
       required:
-      - id
-      - username
+        - id
+        - username

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9,443 +9,441 @@ paths:
       operationId: meta_integrated_system_list
       description: Viewset for IntegratedSystem model.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedIntegratedSystemList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedIntegratedSystemList'
+          description: ''
     post:
       operationId: meta_integrated_system_create
       description: Viewset for IntegratedSystem model.
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
         required: true
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
   /api/v0/meta/integrated_system/{id}/:
     get:
       operationId: meta_integrated_system_retrieve
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     put:
       operationId: meta_integrated_system_update
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     patch:
       operationId: meta_integrated_system_partial_update
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     delete:
       operationId: meta_integrated_system_destroy
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/meta/product/:
     get:
       operationId: meta_product_list
       description: Viewset for Product model.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - in: query
-          name: name
-          schema:
-            type: string
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
-        - in: query
-          name: system__slug
-          schema:
-            type: string
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: system__slug
+        schema:
+          type: string
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedProductList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedProductList'
+          description: ''
     post:
       operationId: meta_product_create
       description: Viewset for Product model.
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
         required: true
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
   /api/v0/meta/product/{id}/:
     get:
       operationId: meta_product_retrieve
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     put:
       operationId: meta_product_update
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     patch:
       operationId: meta_product_partial_update
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     delete:
       operationId: meta_product_destroy
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/meta/product/preload/{system_slug}/{sku}/:
     get:
       operationId: meta_product_preload_retrieve
-      description:
-        Pre-loads the product metadata for a given SKU, even if the SKU
+      description: Pre-loads the product metadata for a given SKU, even if the SKU
         doesn't exist yet.
       parameters:
-        - in: path
-          name: sku
-          schema:
-            type: string
-            pattern: ^[^/]+$
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-            pattern: ^[^/]+$
-          required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
   /api/v0/payments/baskets/:
     get:
       operationId: payments_baskets_list
       description: Retrives the current user's baskets, one per system.
       parameters:
-        - in: query
-          name: integrated_system
-          schema:
-            type: integer
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - in: query
+        name: integrated_system
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedBasketWithProductList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedBasketWithProductList'
+          description: ''
   /api/v0/payments/baskets/{id}/:
     get:
       operationId: payments_baskets_retrieve
       description: Retrieve a basket for the current user.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/add_discount/{system_slug}/:
     post:
       operationId: payments_baskets_add_discount_create
-      description:
-        Creates or updates a basket for the current user, adding the discount
+      description: Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
-        - in: query
-          name: discount_code
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: query
+        name: discount_code
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/clear/{system_slug}/:
     delete:
       operationId: payments_baskets_clear_destroy
       description: Clears the basket for the current user.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/:
     post:
       operationId: payments_baskets_create_from_product_create
-      description:
-        Creates or updates a basket for the current user, adding the selected
+      description: Creates or updates a basket for the current user, adding the selected
         product.
       parameters:
-        - in: path
-          name: sku
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -477,40 +475,48 @@ paths:
                 $ref: "#/components/schemas/BasketWithProduct"
           description: ""
 >>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
+=======
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
+>>>>>>> 941ea5f (update schema)
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/:
     post:
       operationId: create_basket_from_product_with_discount
-      description:
-        Creates or updates a basket for the current user, adding the selected
+      description: Creates or updates a basket for the current user, adding the selected
         product and discount.
       parameters:
-        - in: path
-          name: discount_code
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: sku
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: discount_code
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
+<<<<<<< HEAD
 <<<<<<< HEAD
       - payments
 >>>>>>> b889362 (updating openapi spec)
 =======
         - payments
 >>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
+=======
+      - payments
+>>>>>>> 941ea5f (update schema)
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
+<<<<<<< HEAD
 <<<<<<< HEAD
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
@@ -525,119 +531,122 @@ paths:
                 $ref: "#/components/schemas/BasketWithProduct"
           description: ""
 >>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
+=======
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
+>>>>>>> 941ea5f (update schema)
   /api/v0/payments/baskets/for_system/{system_slug}/:
     get:
       operationId: payments_baskets_for_system_retrieve
       description: Returns or creates a basket for the current user and system.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/checkout/{system_slug}/:
     post:
       operationId: payments_checkout_create
-      description:
-        Generates and returns the form payload for the current basket for
+      description: Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CyberSourceCheckout"
-          description: ""
+                $ref: '#/components/schemas/CyberSourceCheckout'
+          description: ''
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create
       description: Create a discount.
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Discount"
-          description: ""
+                $ref: '#/components/schemas/Discount'
+          description: ''
   /api/v0/payments/orders/history/:
     get:
       operationId: payments_orders_history_list
       description: Retrives the current user's completed orders.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedOrderHistoryList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedOrderHistoryList'
+          description: ''
   /api/v0/payments/orders/history/{id}/:
     get:
       operationId: payments_orders_history_retrieve
       description: Retrieve a completed order for the current user.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrderHistory"
-          description: ""
+                $ref: '#/components/schemas/OrderHistory'
+          description: ''
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
       description: User retrieve and update viewsets for the current user
       tags:
-        - users
+      - users
       security:
-        - {}
+      - {}
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
-          description: ""
+                $ref: '#/components/schemas/User'
+          description: ''
 components:
   schemas:
     BasketItemWithProduct:
@@ -645,7 +654,7 @@ components:
       description: Basket item model serializer with product information
       properties:
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
         id:
           type: integer
           readOnly: true
@@ -669,14 +678,14 @@ components:
           minimum: 0
         discount_applied:
           allOf:
-            - $ref: "#/components/schemas/SimpleDiscount"
+          - $ref: '#/components/schemas/SimpleDiscount'
           readOnly: true
       required:
-        - discount_applied
-        - discounted_price
-        - id
-        - price
-        - product
+      - discount_applied
+      - discounted_price
+      - id
+      - price
+      - product
     BasketWithProduct:
       type: object
       description: Basket model serializer with items and products
@@ -687,11 +696,11 @@ components:
         user:
           type: integer
         integrated_system:
-          $ref: "#/components/schemas/IntegratedSystem"
+          $ref: '#/components/schemas/IntegratedSystem'
         basket_items:
           type: array
           items:
-            $ref: "#/components/schemas/BasketItemWithProduct"
+            $ref: '#/components/schemas/BasketItemWithProduct'
         subtotal:
           type: number
           format: double
@@ -703,21 +712,21 @@ components:
           description: Get the tax for the basket
           readOnly: true
         tax_rate:
-          $ref: "#/components/schemas/TaxRate"
+          $ref: '#/components/schemas/TaxRate'
         total_price:
           type: number
           format: double
           description: Get the total price for the basket
           readOnly: true
       required:
-        - basket_items
-        - id
-        - integrated_system
-        - subtotal
-        - tax
-        - tax_rate
-        - total_price
-        - user
+      - basket_items
+      - id
+      - integrated_system
+      - subtotal
+      - tax
+      - tax_rate
+      - total_price
+      - user
     Company:
       type: object
       description: Serializer for companies.
@@ -729,259 +738,259 @@ components:
           type: string
           maxLength: 255
       required:
-        - id
-        - name
+      - id
+      - name
     CountryCodeEnum:
       enum:
-        - AF
-        - AX
-        - AL
-        - DZ
-        - AS
-        - AD
-        - AO
-        - AI
-        - AQ
-        - AG
-        - AR
-        - AM
-        - AW
-        - AU
-        - AT
-        - AZ
-        - BS
-        - BH
-        - BD
-        - BB
-        - BY
-        - BE
-        - BZ
-        - BJ
-        - BM
-        - BT
-        - BO
-        - BQ
-        - BA
-        - BW
-        - BV
-        - BR
-        - IO
-        - BN
-        - BG
-        - BF
-        - BI
-        - CV
-        - KH
-        - CM
-        - CA
-        - KY
-        - CF
-        - TD
-        - CL
-        - CN
-        - CX
-        - CC
-        - CO
-        - KM
-        - CG
-        - CD
-        - CK
-        - CR
-        - CI
-        - HR
-        - CU
-        - CW
-        - CY
-        - CZ
-        - DK
-        - DJ
-        - DM
-        - DO
-        - EC
-        - EG
-        - SV
-        - GQ
-        - ER
-        - EE
-        - SZ
-        - ET
-        - FK
-        - FO
-        - FJ
-        - FI
-        - FR
-        - GF
-        - PF
-        - TF
-        - GA
-        - GM
-        - GE
-        - DE
-        - GH
-        - GI
-        - GR
-        - GL
-        - GD
-        - GP
-        - GU
-        - GT
-        - GG
-        - GN
-        - GW
-        - GY
-        - HT
-        - HM
-        - VA
-        - HN
-        - HK
-        - HU
-        - IS
-        - IN
-        - ID
-        - IR
-        - IQ
-        - IE
-        - IM
-        - IL
-        - IT
-        - JM
-        - JP
-        - JE
-        - JO
-        - KZ
-        - KE
-        - KI
-        - KW
-        - KG
-        - LA
-        - LV
-        - LB
-        - LS
-        - LR
-        - LY
-        - LI
-        - LT
-        - LU
-        - MO
-        - MG
-        - MW
-        - MY
-        - MV
-        - ML
-        - MT
-        - MH
-        - MQ
-        - MR
-        - MU
-        - YT
-        - MX
-        - FM
-        - MD
-        - MC
-        - MN
-        - ME
-        - MS
-        - MA
-        - MZ
-        - MM
-        - NA
-        - NR
-        - NP
-        - NL
-        - NC
-        - NZ
-        - NI
-        - NE
-        - NG
-        - NU
-        - NF
-        - KP
-        - MK
-        - MP
-        - "NO"
-        - OM
-        - PK
-        - PW
-        - PS
-        - PA
-        - PG
-        - PY
-        - PE
-        - PH
-        - PN
-        - PL
-        - PT
-        - PR
-        - QA
-        - RE
-        - RO
-        - RU
-        - RW
-        - BL
-        - SH
-        - KN
-        - LC
-        - MF
-        - PM
-        - VC
-        - WS
-        - SM
-        - ST
-        - SA
-        - SN
-        - RS
-        - SC
-        - SL
-        - SG
-        - SX
-        - SK
-        - SI
-        - SB
-        - SO
-        - ZA
-        - GS
-        - KR
-        - SS
-        - ES
-        - LK
-        - SD
-        - SR
-        - SJ
-        - SE
-        - CH
-        - SY
-        - TW
-        - TJ
-        - TZ
-        - TH
-        - TL
-        - TG
-        - TK
-        - TO
-        - TT
-        - TN
-        - TR
-        - TM
-        - TC
-        - TV
-        - UG
-        - UA
-        - AE
-        - GB
-        - UM
-        - US
-        - UY
-        - UZ
-        - VU
-        - VE
-        - VN
-        - VG
-        - VI
-        - WF
-        - EH
-        - YE
-        - ZM
-        - ZW
+      - AF
+      - AX
+      - AL
+      - DZ
+      - AS
+      - AD
+      - AO
+      - AI
+      - AQ
+      - AG
+      - AR
+      - AM
+      - AW
+      - AU
+      - AT
+      - AZ
+      - BS
+      - BH
+      - BD
+      - BB
+      - BY
+      - BE
+      - BZ
+      - BJ
+      - BM
+      - BT
+      - BO
+      - BQ
+      - BA
+      - BW
+      - BV
+      - BR
+      - IO
+      - BN
+      - BG
+      - BF
+      - BI
+      - CV
+      - KH
+      - CM
+      - CA
+      - KY
+      - CF
+      - TD
+      - CL
+      - CN
+      - CX
+      - CC
+      - CO
+      - KM
+      - CG
+      - CD
+      - CK
+      - CR
+      - CI
+      - HR
+      - CU
+      - CW
+      - CY
+      - CZ
+      - DK
+      - DJ
+      - DM
+      - DO
+      - EC
+      - EG
+      - SV
+      - GQ
+      - ER
+      - EE
+      - SZ
+      - ET
+      - FK
+      - FO
+      - FJ
+      - FI
+      - FR
+      - GF
+      - PF
+      - TF
+      - GA
+      - GM
+      - GE
+      - DE
+      - GH
+      - GI
+      - GR
+      - GL
+      - GD
+      - GP
+      - GU
+      - GT
+      - GG
+      - GN
+      - GW
+      - GY
+      - HT
+      - HM
+      - VA
+      - HN
+      - HK
+      - HU
+      - IS
+      - IN
+      - ID
+      - IR
+      - IQ
+      - IE
+      - IM
+      - IL
+      - IT
+      - JM
+      - JP
+      - JE
+      - JO
+      - KZ
+      - KE
+      - KI
+      - KW
+      - KG
+      - LA
+      - LV
+      - LB
+      - LS
+      - LR
+      - LY
+      - LI
+      - LT
+      - LU
+      - MO
+      - MG
+      - MW
+      - MY
+      - MV
+      - ML
+      - MT
+      - MH
+      - MQ
+      - MR
+      - MU
+      - YT
+      - MX
+      - FM
+      - MD
+      - MC
+      - MN
+      - ME
+      - MS
+      - MA
+      - MZ
+      - MM
+      - NA
+      - NR
+      - NP
+      - NL
+      - NC
+      - NZ
+      - NI
+      - NE
+      - NG
+      - NU
+      - NF
+      - KP
+      - MK
+      - MP
+      - 'NO'
+      - OM
+      - PK
+      - PW
+      - PS
+      - PA
+      - PG
+      - PY
+      - PE
+      - PH
+      - PN
+      - PL
+      - PT
+      - PR
+      - QA
+      - RE
+      - RO
+      - RU
+      - RW
+      - BL
+      - SH
+      - KN
+      - LC
+      - MF
+      - PM
+      - VC
+      - WS
+      - SM
+      - ST
+      - SA
+      - SN
+      - RS
+      - SC
+      - SL
+      - SG
+      - SX
+      - SK
+      - SI
+      - SB
+      - SO
+      - ZA
+      - GS
+      - KR
+      - SS
+      - ES
+      - LK
+      - SD
+      - SR
+      - SJ
+      - SE
+      - CH
+      - SY
+      - TW
+      - TJ
+      - TZ
+      - TH
+      - TL
+      - TG
+      - TK
+      - TO
+      - TT
+      - TN
+      - TR
+      - TM
+      - TC
+      - TV
+      - UG
+      - UA
+      - AE
+      - GB
+      - UM
+      - US
+      - UY
+      - UZ
+      - VU
+      - VE
+      - VN
+      - VG
+      - VI
+      - WF
+      - EH
+      - YE
+      - ZM
+      - ZW
       type: string
       description: |-
         * `AF` - Afghanistan
@@ -1237,8 +1246,11 @@ components:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 >>>>>>> b889362 (updating openapi spec)
+=======
+>>>>>>> 941ea5f (update schema)
       - Afghanistan
       - Åland Islands
       - Albania
@@ -1488,6 +1500,7 @@ components:
       - Yemen
       - Zambia
       - Zimbabwe
+<<<<<<< HEAD
 <<<<<<< HEAD
     CreateBasketWithProductsRequest:
       type: object
@@ -1781,10 +1794,11 @@ components:
 >>>>>>> b889362 (updating openapi spec)
 =======
 >>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
+=======
+>>>>>>> 941ea5f (update schema)
     CyberSourceCheckout:
       type: object
-      description:
-        Really basic serializer for the payload that we need to send to
+      description: Really basic serializer for the payload that we need to send to
         CyberSource.
       properties:
         payload:
@@ -1795,9 +1809,9 @@ components:
         method:
           type: string
       required:
-        - method
-        - payload
-        - url
+      - method
+      - payload
+      - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -1815,8 +1829,8 @@ components:
         payment_type:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/PaymentTypeEnum"
-            - $ref: "#/components/schemas/NullEnum"
+          - $ref: '#/components/schemas/PaymentTypeEnum'
+          - $ref: '#/components/schemas/NullEnum'
         max_redemptions:
           type: integer
           maximum: 2147483647
@@ -1826,48 +1840,46 @@ components:
           type: string
           format: date-time
           nullable: true
-          description:
-            If set, this discount code will not be redeemable before this
+          description: If set, this discount code will not be redeemable before this
             date.
         expiration_date:
           type: string
           format: date-time
           nullable: true
-          description:
-            If set, this discount code will not be redeemable after this
+          description: If set, this discount code will not be redeemable after this
             date.
         integrated_system:
-          $ref: "#/components/schemas/IntegratedSystem"
+          $ref: '#/components/schemas/IntegratedSystem'
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
         assigned_users:
           type: array
           items:
-            $ref: "#/components/schemas/User"
+            $ref: '#/components/schemas/User'
         company:
-          $ref: "#/components/schemas/Company"
+          $ref: '#/components/schemas/Company'
       required:
-        - amount
-        - assigned_users
-        - company
-        - discount_code
-        - id
-        - integrated_system
-        - product
+      - amount
+      - assigned_users
+      - company
+      - discount_code
+      - id
+      - integrated_system
+      - product
     DiscountTypeEnum:
       enum:
-        - percent-off
-        - dollars-off
-        - fixed-price
+      - percent-off
+      - dollars-off
+      - fixed-price
       type: string
       description: |-
         * `percent-off` - percent-off
         * `dollars-off` - dollars-off
         * `fixed-price` - fixed-price
       x-enum-descriptions:
-        - percent-off
-        - dollars-off
-        - fixed-price
+      - percent-off
+      - dollars-off
+      - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1885,8 +1897,8 @@ components:
         description:
           type: string
       required:
-        - id
-        - name
+      - id
+      - name
     IntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1902,7 +1914,7 @@ components:
         description:
           type: string
       required:
-        - name
+      - name
     Line:
       type: object
       description: Serializes a line item for an order.
@@ -1927,17 +1939,17 @@ components:
           format: decimal
           pattern: ^-?\d{0,7}(?:\.\d{0,2})?$
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
       required:
-        - id
-        - item_description
-        - product
-        - quantity
-        - total_price
-        - unit_price
+      - id
+      - item_description
+      - product
+      - quantity
+      - total_price
+      - unit_price
     NullEnum:
       enum:
-        - null
+      - null
     OrderHistory:
       type: object
       description: Serializer for order history.
@@ -1946,7 +1958,7 @@ components:
           type: integer
           readOnly: true
         state:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         reference_number:
           type: string
           maxLength: 255
@@ -1959,7 +1971,7 @@ components:
         lines:
           type: array
           items:
-            $ref: "#/components/schemas/Line"
+            $ref: '#/components/schemas/Line'
         created_on:
           type: string
           format: date-time
@@ -1969,17 +1981,17 @@ components:
           format: date-time
           readOnly: true
       required:
-        - created_on
-        - id
-        - lines
-        - purchaser
-        - total_price_paid
-        - updated_on
+      - created_on
+      - id
+      - lines
+      - purchaser
+      - total_price_paid
+      - updated_on
     PaginatedBasketWithProductList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1997,12 +2009,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/BasketWithProduct"
+            $ref: '#/components/schemas/BasketWithProduct'
     PaginatedIntegratedSystemList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -2020,12 +2032,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/IntegratedSystem"
+            $ref: '#/components/schemas/IntegratedSystem'
     PaginatedOrderHistoryList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -2043,12 +2055,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/OrderHistory"
+            $ref: '#/components/schemas/OrderHistory'
     PaginatedProductList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -2066,7 +2078,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Product"
+            $ref: '#/components/schemas/Product'
     PatchedIntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -2112,19 +2124,18 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
     PaymentTypeEnum:
       enum:
-        - marketing
-        - sales
-        - financial-assistance
-        - customer-support
-        - staff
-        - legacy
-        - credit_card
-        - purchase_order
+      - marketing
+      - sales
+      - financial-assistance
+      - customer-support
+      - staff
+      - legacy
+      - credit_card
+      - purchase_order
       type: string
       description: |-
         * `marketing` - marketing
@@ -2136,14 +2147,14 @@ components:
         * `credit_card` - credit_card
         * `purchase_order` - purchase_order
       x-enum-descriptions:
-        - marketing
-        - sales
-        - financial-assistance
-        - customer-support
-        - staff
-        - legacy
-        - credit_card
-        - purchase_order
+      - marketing
+      - sales
+      - financial-assistance
+      - customer-support
+      - staff
+      - legacy
+      - credit_card
+      - purchase_order
     Product:
       type: object
       description: Serializer for Product model.
@@ -2178,17 +2189,16 @@ components:
           readOnly: true
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
       required:
-        - deleted_by_cascade
-        - description
-        - id
-        - name
-        - price
-        - sku
-        - system
+      - deleted_by_cascade
+      - description
+      - id
+      - name
+      - price
+      - sku
+      - system
     ProductRequest:
       type: object
       description: Serializer for Product model.
@@ -2220,15 +2230,14 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
       required:
-        - description
-        - name
-        - price
-        - sku
-        - system
+      - description
+      - name
+      - price
+      - sku
+      - system
     SimpleDiscount:
       type: object
       description: Simpler serializer for discounts.
@@ -2244,7 +2253,7 @@ components:
           format: decimal
           pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
         discount_type:
-          $ref: "#/components/schemas/DiscountTypeEnum"
+          $ref: '#/components/schemas/DiscountTypeEnum'
         formatted_discount_amount:
           type: string
           description: |-
@@ -2253,20 +2262,20 @@ components:
             This quantizes percent discounts to whole numbers. This is probably fine.
           readOnly: true
       required:
-        - amount
-        - discount_code
-        - discount_type
-        - formatted_discount_amount
-        - id
+      - amount
+      - discount_code
+      - discount_type
+      - formatted_discount_amount
+      - id
     StateEnum:
       enum:
-        - pending
-        - fulfilled
-        - canceled
-        - refunded
-        - declined
-        - errored
-        - review
+      - pending
+      - fulfilled
+      - canceled
+      - refunded
+      - declined
+      - errored
+      - review
       type: string
       description: |-
         * `pending` - Pending
@@ -2277,13 +2286,13 @@ components:
         * `errored` - Errored
         * `review` - Review
       x-enum-descriptions:
-        - Pending
-        - Fulfilled
-        - Canceled
-        - Refunded
-        - Declined
-        - Errored
-        - Review
+      - Pending
+      - Fulfilled
+      - Canceled
+      - Refunded
+      - Declined
+      - Errored
+      - Review
     TaxRate:
       type: object
       description: TaxRate model serializer
@@ -2292,7 +2301,7 @@ components:
           type: integer
           readOnly: true
         country_code:
-          $ref: "#/components/schemas/CountryCodeEnum"
+          $ref: '#/components/schemas/CountryCodeEnum'
         tax_rate:
           type: string
           format: decimal
@@ -2301,8 +2310,8 @@ components:
           type: string
           maxLength: 100
       required:
-        - country_code
-        - id
+      - country_code
+      - id
     User:
       type: object
       description: Serializer for User model.
@@ -2312,8 +2321,7 @@ components:
           readOnly: true
         username:
           type: string
-          description:
-            Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
@@ -2329,5 +2337,5 @@ components:
           type: string
           maxLength: 150
       required:
-        - id
-        - username
+      - id
+      - username

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9,616 +9,610 @@ paths:
       operationId: meta_integrated_system_list
       description: Viewset for IntegratedSystem model.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedIntegratedSystemList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedIntegratedSystemList'
+          description: ''
     post:
       operationId: meta_integrated_system_create
       description: Viewset for IntegratedSystem model.
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
         required: true
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
   /api/v0/meta/integrated_system/{id}/:
     get:
       operationId: meta_integrated_system_retrieve
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     put:
       operationId: meta_integrated_system_update
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/IntegratedSystemRequest"
+              $ref: '#/components/schemas/IntegratedSystemRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     patch:
       operationId: meta_integrated_system_partial_update
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
+              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IntegratedSystem"
-          description: ""
+                $ref: '#/components/schemas/IntegratedSystem'
+          description: ''
     delete:
       operationId: meta_integrated_system_destroy
       description: Viewset for IntegratedSystem model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this integrated system.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this integrated system.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/meta/product/:
     get:
       operationId: meta_product_list
       description: Viewset for Product model.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - in: query
-          name: name
-          schema:
-            type: string
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
-        - in: query
-          name: system__slug
-          schema:
-            type: string
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: system__slug
+        schema:
+          type: string
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedProductList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedProductList'
+          description: ''
     post:
       operationId: meta_product_create
       description: Viewset for Product model.
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
         required: true
       responses:
-        "201":
+        '201':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
   /api/v0/meta/product/{id}/:
     get:
       operationId: meta_product_retrieve
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     put:
       operationId: meta_product_update
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/ProductRequest"
+              $ref: '#/components/schemas/ProductRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     patch:
       operationId: meta_product_partial_update
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/PatchedProductRequest"
+              $ref: '#/components/schemas/PatchedProductRequest'
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
     delete:
       operationId: meta_product_destroy
       description: Viewset for Product model.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          description: A unique integer value identifying this product.
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this product.
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/meta/product/preload/{system_slug}/{sku}/:
     get:
       operationId: meta_product_preload_retrieve
-      description:
-        Pre-loads the product metadata for a given SKU, even if the SKU
+      description: Pre-loads the product metadata for a given SKU, even if the SKU
         doesn't exist yet.
       parameters:
-        - in: path
-          name: sku
-          schema:
-            type: string
-            pattern: ^[^/]+$
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-            pattern: ^[^/]+$
-          required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+          pattern: ^[^/]+$
+        required: true
       tags:
-        - meta
+      - meta
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Product"
-          description: ""
+                $ref: '#/components/schemas/Product'
+          description: ''
   /api/v0/payments/baskets/:
     get:
       operationId: payments_baskets_list
       description: Retrives the current user's baskets, one per system.
       parameters:
-        - in: query
-          name: integrated_system
-          schema:
-            type: integer
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - in: query
+        name: integrated_system
+        schema:
+          type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedBasketWithProductList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedBasketWithProductList'
+          description: ''
   /api/v0/payments/baskets/{id}/:
     get:
       operationId: payments_baskets_retrieve
       description: Retrieve a basket for the current user.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/add_discount/{system_slug}/:
     post:
       operationId: payments_baskets_add_discount_create
-      description:
-        Creates or updates a basket for the current user, adding the discount
+      description: Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
-        - in: query
-          name: discount_code
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: query
+        name: discount_code
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/clear/{system_slug}/:
     delete:
       operationId: payments_baskets_clear_destroy
       description: Clears the basket for the current user.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "204":
+        '204':
           description: No response body
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/:
     post:
       operationId: payments_baskets_create_from_product_create
-      description:
-        Creates or updates a basket for the current user, adding the selected
+      description: Creates or updates a basket for the current user, adding the selected
         product.
       parameters:
-        - in: path
-          name: sku
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/:
     post:
       operationId: create_basket_from_product_with_discount
-      description:
-        Creates or updates a basket for the current user, adding the selected
+      description: Creates or updates a basket for the current user, adding the selected
         product and discount.
       parameters:
-        - in: path
-          name: discount_code
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: sku
-          schema:
-            type: string
-          required: true
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: discount_code
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: sku
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/create_with_products/:
     post:
       operationId: payments_baskets_create_with_products_create
-      description:
-        Creates or updates a basket for the current user, adding the selected
+      description: Creates or updates a basket for the current user, adding the selected
         product.
       tags:
-        - payments
+      - payments
       requestBody:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
           multipart/form-data:
             schema:
-              $ref: "#/components/schemas/CreateBasketWithProductsRequest"
+              $ref: '#/components/schemas/CreateBasketWithProductsRequest'
         required: true
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/baskets/for_system/{system_slug}/:
     get:
       operationId: payments_baskets_for_system_retrieve
       description: Returns or creates a basket for the current user and system.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasketWithProduct"
-          description: ""
+                $ref: '#/components/schemas/BasketWithProduct'
+          description: ''
   /api/v0/payments/checkout/{system_slug}/:
     post:
       operationId: payments_checkout_create
-      description:
-        Generates and returns the form payload for the current basket for
+      description: Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:
-        - in: path
-          name: system_slug
-          schema:
-            type: string
-          required: true
+      - in: path
+        name: system_slug
+        schema:
+          type: string
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CyberSourceCheckout"
-          description: ""
+                $ref: '#/components/schemas/CyberSourceCheckout'
+          description: ''
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create
       description: Create a discount.
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Discount"
-          description: ""
+                $ref: '#/components/schemas/Discount'
+          description: ''
   /api/v0/payments/orders/history/:
     get:
       operationId: payments_orders_history_list
       description: Retrives the current user's completed orders.
       parameters:
-        - name: limit
-          required: false
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
-        - name: offset
-          required: false
-          in: query
-          description: The initial index from which to return the results.
-          schema:
-            type: integer
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PaginatedOrderHistoryList"
-          description: ""
+                $ref: '#/components/schemas/PaginatedOrderHistoryList'
+          description: ''
   /api/v0/payments/orders/history/{id}/:
     get:
       operationId: payments_orders_history_retrieve
       description: Retrieve a completed order for the current user.
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: integer
-          required: true
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
       tags:
-        - payments
+      - payments
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/OrderHistory"
-          description: ""
+                $ref: '#/components/schemas/OrderHistory'
+          description: ''
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
       description: User retrieve and update viewsets for the current user
       tags:
-        - users
+      - users
       security:
-        - {}
+      - {}
       responses:
-        "200":
+        '200':
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/User"
-          description: ""
+                $ref: '#/components/schemas/User'
+          description: ''
 components:
   schemas:
     BasketItemWithProduct:
@@ -626,7 +620,7 @@ components:
       description: Basket item model serializer with product information
       properties:
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
         id:
           type: integer
           readOnly: true
@@ -650,14 +644,14 @@ components:
           minimum: 0
         discount_applied:
           allOf:
-            - $ref: "#/components/schemas/SimpleDiscount"
+          - $ref: '#/components/schemas/SimpleDiscount'
           readOnly: true
       required:
-        - discount_applied
-        - discounted_price
-        - id
-        - price
-        - product
+      - discount_applied
+      - discounted_price
+      - id
+      - price
+      - product
     BasketWithProduct:
       type: object
       description: Basket model serializer with items and products
@@ -668,11 +662,11 @@ components:
         user:
           type: integer
         integrated_system:
-          $ref: "#/components/schemas/IntegratedSystem"
+          $ref: '#/components/schemas/IntegratedSystem'
         basket_items:
           type: array
           items:
-            $ref: "#/components/schemas/BasketItemWithProduct"
+            $ref: '#/components/schemas/BasketItemWithProduct'
         subtotal:
           type: number
           format: double
@@ -684,21 +678,21 @@ components:
           description: Get the tax for the basket
           readOnly: true
         tax_rate:
-          $ref: "#/components/schemas/TaxRate"
+          $ref: '#/components/schemas/TaxRate'
         total_price:
           type: number
           format: double
           description: Get the total price for the basket
           readOnly: true
       required:
-        - basket_items
-        - id
-        - integrated_system
-        - subtotal
-        - tax
-        - tax_rate
-        - total_price
-        - user
+      - basket_items
+      - id
+      - integrated_system
+      - subtotal
+      - tax
+      - tax_rate
+      - total_price
+      - user
     Company:
       type: object
       description: Serializer for companies.
@@ -710,259 +704,259 @@ components:
           type: string
           maxLength: 255
       required:
-        - id
-        - name
+      - id
+      - name
     CountryCodeEnum:
       enum:
-        - AF
-        - AX
-        - AL
-        - DZ
-        - AS
-        - AD
-        - AO
-        - AI
-        - AQ
-        - AG
-        - AR
-        - AM
-        - AW
-        - AU
-        - AT
-        - AZ
-        - BS
-        - BH
-        - BD
-        - BB
-        - BY
-        - BE
-        - BZ
-        - BJ
-        - BM
-        - BT
-        - BO
-        - BQ
-        - BA
-        - BW
-        - BV
-        - BR
-        - IO
-        - BN
-        - BG
-        - BF
-        - BI
-        - CV
-        - KH
-        - CM
-        - CA
-        - KY
-        - CF
-        - TD
-        - CL
-        - CN
-        - CX
-        - CC
-        - CO
-        - KM
-        - CG
-        - CD
-        - CK
-        - CR
-        - CI
-        - HR
-        - CU
-        - CW
-        - CY
-        - CZ
-        - DK
-        - DJ
-        - DM
-        - DO
-        - EC
-        - EG
-        - SV
-        - GQ
-        - ER
-        - EE
-        - SZ
-        - ET
-        - FK
-        - FO
-        - FJ
-        - FI
-        - FR
-        - GF
-        - PF
-        - TF
-        - GA
-        - GM
-        - GE
-        - DE
-        - GH
-        - GI
-        - GR
-        - GL
-        - GD
-        - GP
-        - GU
-        - GT
-        - GG
-        - GN
-        - GW
-        - GY
-        - HT
-        - HM
-        - VA
-        - HN
-        - HK
-        - HU
-        - IS
-        - IN
-        - ID
-        - IR
-        - IQ
-        - IE
-        - IM
-        - IL
-        - IT
-        - JM
-        - JP
-        - JE
-        - JO
-        - KZ
-        - KE
-        - KI
-        - KW
-        - KG
-        - LA
-        - LV
-        - LB
-        - LS
-        - LR
-        - LY
-        - LI
-        - LT
-        - LU
-        - MO
-        - MG
-        - MW
-        - MY
-        - MV
-        - ML
-        - MT
-        - MH
-        - MQ
-        - MR
-        - MU
-        - YT
-        - MX
-        - FM
-        - MD
-        - MC
-        - MN
-        - ME
-        - MS
-        - MA
-        - MZ
-        - MM
-        - NA
-        - NR
-        - NP
-        - NL
-        - NC
-        - NZ
-        - NI
-        - NE
-        - NG
-        - NU
-        - NF
-        - KP
-        - MK
-        - MP
-        - "NO"
-        - OM
-        - PK
-        - PW
-        - PS
-        - PA
-        - PG
-        - PY
-        - PE
-        - PH
-        - PN
-        - PL
-        - PT
-        - PR
-        - QA
-        - RE
-        - RO
-        - RU
-        - RW
-        - BL
-        - SH
-        - KN
-        - LC
-        - MF
-        - PM
-        - VC
-        - WS
-        - SM
-        - ST
-        - SA
-        - SN
-        - RS
-        - SC
-        - SL
-        - SG
-        - SX
-        - SK
-        - SI
-        - SB
-        - SO
-        - ZA
-        - GS
-        - KR
-        - SS
-        - ES
-        - LK
-        - SD
-        - SR
-        - SJ
-        - SE
-        - CH
-        - SY
-        - TW
-        - TJ
-        - TZ
-        - TH
-        - TL
-        - TG
-        - TK
-        - TO
-        - TT
-        - TN
-        - TR
-        - TM
-        - TC
-        - TV
-        - UG
-        - UA
-        - AE
-        - GB
-        - UM
-        - US
-        - UY
-        - UZ
-        - VU
-        - VE
-        - VN
-        - VG
-        - VI
-        - WF
-        - EH
-        - YE
-        - ZM
-        - ZW
+      - AF
+      - AX
+      - AL
+      - DZ
+      - AS
+      - AD
+      - AO
+      - AI
+      - AQ
+      - AG
+      - AR
+      - AM
+      - AW
+      - AU
+      - AT
+      - AZ
+      - BS
+      - BH
+      - BD
+      - BB
+      - BY
+      - BE
+      - BZ
+      - BJ
+      - BM
+      - BT
+      - BO
+      - BQ
+      - BA
+      - BW
+      - BV
+      - BR
+      - IO
+      - BN
+      - BG
+      - BF
+      - BI
+      - CV
+      - KH
+      - CM
+      - CA
+      - KY
+      - CF
+      - TD
+      - CL
+      - CN
+      - CX
+      - CC
+      - CO
+      - KM
+      - CG
+      - CD
+      - CK
+      - CR
+      - CI
+      - HR
+      - CU
+      - CW
+      - CY
+      - CZ
+      - DK
+      - DJ
+      - DM
+      - DO
+      - EC
+      - EG
+      - SV
+      - GQ
+      - ER
+      - EE
+      - SZ
+      - ET
+      - FK
+      - FO
+      - FJ
+      - FI
+      - FR
+      - GF
+      - PF
+      - TF
+      - GA
+      - GM
+      - GE
+      - DE
+      - GH
+      - GI
+      - GR
+      - GL
+      - GD
+      - GP
+      - GU
+      - GT
+      - GG
+      - GN
+      - GW
+      - GY
+      - HT
+      - HM
+      - VA
+      - HN
+      - HK
+      - HU
+      - IS
+      - IN
+      - ID
+      - IR
+      - IQ
+      - IE
+      - IM
+      - IL
+      - IT
+      - JM
+      - JP
+      - JE
+      - JO
+      - KZ
+      - KE
+      - KI
+      - KW
+      - KG
+      - LA
+      - LV
+      - LB
+      - LS
+      - LR
+      - LY
+      - LI
+      - LT
+      - LU
+      - MO
+      - MG
+      - MW
+      - MY
+      - MV
+      - ML
+      - MT
+      - MH
+      - MQ
+      - MR
+      - MU
+      - YT
+      - MX
+      - FM
+      - MD
+      - MC
+      - MN
+      - ME
+      - MS
+      - MA
+      - MZ
+      - MM
+      - NA
+      - NR
+      - NP
+      - NL
+      - NC
+      - NZ
+      - NI
+      - NE
+      - NG
+      - NU
+      - NF
+      - KP
+      - MK
+      - MP
+      - 'NO'
+      - OM
+      - PK
+      - PW
+      - PS
+      - PA
+      - PG
+      - PY
+      - PE
+      - PH
+      - PN
+      - PL
+      - PT
+      - PR
+      - QA
+      - RE
+      - RO
+      - RU
+      - RW
+      - BL
+      - SH
+      - KN
+      - LC
+      - MF
+      - PM
+      - VC
+      - WS
+      - SM
+      - ST
+      - SA
+      - SN
+      - RS
+      - SC
+      - SL
+      - SG
+      - SX
+      - SK
+      - SI
+      - SB
+      - SO
+      - ZA
+      - GS
+      - KR
+      - SS
+      - ES
+      - LK
+      - SD
+      - SR
+      - SJ
+      - SE
+      - CH
+      - SY
+      - TW
+      - TJ
+      - TZ
+      - TH
+      - TL
+      - TG
+      - TK
+      - TO
+      - TT
+      - TN
+      - TR
+      - TM
+      - TC
+      - TV
+      - UG
+      - UA
+      - AE
+      - GB
+      - UM
+      - US
+      - UY
+      - UZ
+      - VU
+      - VE
+      - VN
+      - VG
+      - VI
+      - WF
+      - EH
+      - YE
+      - ZM
+      - ZW
       type: string
       description: |-
         * `AF` - Afghanistan
@@ -1215,255 +1209,255 @@ components:
         * `ZM` - Zambia
         * `ZW` - Zimbabwe
       x-enum-descriptions:
-        - Afghanistan
-        - Åland Islands
-        - Albania
-        - Algeria
-        - American Samoa
-        - Andorra
-        - Angola
-        - Anguilla
-        - Antarctica
-        - Antigua and Barbuda
-        - Argentina
-        - Armenia
-        - Aruba
-        - Australia
-        - Austria
-        - Azerbaijan
-        - Bahamas
-        - Bahrain
-        - Bangladesh
-        - Barbados
-        - Belarus
-        - Belgium
-        - Belize
-        - Benin
-        - Bermuda
-        - Bhutan
-        - Bolivia
-        - Bonaire, Sint Eustatius and Saba
-        - Bosnia and Herzegovina
-        - Botswana
-        - Bouvet Island
-        - Brazil
-        - British Indian Ocean Territory
-        - Brunei
-        - Bulgaria
-        - Burkina Faso
-        - Burundi
-        - Cabo Verde
-        - Cambodia
-        - Cameroon
-        - Canada
-        - Cayman Islands
-        - Central African Republic
-        - Chad
-        - Chile
-        - China
-        - Christmas Island
-        - Cocos (Keeling) Islands
-        - Colombia
-        - Comoros
-        - Congo
-        - Congo (the Democratic Republic of the)
-        - Cook Islands
-        - Costa Rica
-        - Côte d'Ivoire
-        - Croatia
-        - Cuba
-        - Curaçao
-        - Cyprus
-        - Czechia
-        - Denmark
-        - Djibouti
-        - Dominica
-        - Dominican Republic
-        - Ecuador
-        - Egypt
-        - El Salvador
-        - Equatorial Guinea
-        - Eritrea
-        - Estonia
-        - Eswatini
-        - Ethiopia
-        - Falkland Islands (Malvinas)
-        - Faroe Islands
-        - Fiji
-        - Finland
-        - France
-        - French Guiana
-        - French Polynesia
-        - French Southern Territories
-        - Gabon
-        - Gambia
-        - Georgia
-        - Germany
-        - Ghana
-        - Gibraltar
-        - Greece
-        - Greenland
-        - Grenada
-        - Guadeloupe
-        - Guam
-        - Guatemala
-        - Guernsey
-        - Guinea
-        - Guinea-Bissau
-        - Guyana
-        - Haiti
-        - Heard Island and McDonald Islands
-        - Holy See
-        - Honduras
-        - Hong Kong
-        - Hungary
-        - Iceland
-        - India
-        - Indonesia
-        - Iran
-        - Iraq
-        - Ireland
-        - Isle of Man
-        - Israel
-        - Italy
-        - Jamaica
-        - Japan
-        - Jersey
-        - Jordan
-        - Kazakhstan
-        - Kenya
-        - Kiribati
-        - Kuwait
-        - Kyrgyzstan
-        - Laos
-        - Latvia
-        - Lebanon
-        - Lesotho
-        - Liberia
-        - Libya
-        - Liechtenstein
-        - Lithuania
-        - Luxembourg
-        - Macao
-        - Madagascar
-        - Malawi
-        - Malaysia
-        - Maldives
-        - Mali
-        - Malta
-        - Marshall Islands
-        - Martinique
-        - Mauritania
-        - Mauritius
-        - Mayotte
-        - Mexico
-        - Micronesia
-        - Moldova
-        - Monaco
-        - Mongolia
-        - Montenegro
-        - Montserrat
-        - Morocco
-        - Mozambique
-        - Myanmar
-        - Namibia
-        - Nauru
-        - Nepal
-        - Netherlands
-        - New Caledonia
-        - New Zealand
-        - Nicaragua
-        - Niger
-        - Nigeria
-        - Niue
-        - Norfolk Island
-        - North Korea
-        - North Macedonia
-        - Northern Mariana Islands
-        - Norway
-        - Oman
-        - Pakistan
-        - Palau
-        - Palestine, State of
-        - Panama
-        - Papua New Guinea
-        - Paraguay
-        - Peru
-        - Philippines
-        - Pitcairn
-        - Poland
-        - Portugal
-        - Puerto Rico
-        - Qatar
-        - Réunion
-        - Romania
-        - Russia
-        - Rwanda
-        - Saint Barthélemy
-        - Saint Helena, Ascension and Tristan da Cunha
-        - Saint Kitts and Nevis
-        - Saint Lucia
-        - Saint Martin (French part)
-        - Saint Pierre and Miquelon
-        - Saint Vincent and the Grenadines
-        - Samoa
-        - San Marino
-        - Sao Tome and Principe
-        - Saudi Arabia
-        - Senegal
-        - Serbia
-        - Seychelles
-        - Sierra Leone
-        - Singapore
-        - Sint Maarten (Dutch part)
-        - Slovakia
-        - Slovenia
-        - Solomon Islands
-        - Somalia
-        - South Africa
-        - South Georgia and the South Sandwich Islands
-        - South Korea
-        - South Sudan
-        - Spain
-        - Sri Lanka
-        - Sudan
-        - Suriname
-        - Svalbard and Jan Mayen
-        - Sweden
-        - Switzerland
-        - Syria
-        - Taiwan
-        - Tajikistan
-        - Tanzania
-        - Thailand
-        - Timor-Leste
-        - Togo
-        - Tokelau
-        - Tonga
-        - Trinidad and Tobago
-        - Tunisia
-        - Türkiye
-        - Turkmenistan
-        - Turks and Caicos Islands
-        - Tuvalu
-        - Uganda
-        - Ukraine
-        - United Arab Emirates
-        - United Kingdom
-        - United States Minor Outlying Islands
-        - United States of America
-        - Uruguay
-        - Uzbekistan
-        - Vanuatu
-        - Venezuela
-        - Vietnam
-        - Virgin Islands (British)
-        - Virgin Islands (U.S.)
-        - Wallis and Futuna
-        - Western Sahara
-        - Yemen
-        - Zambia
-        - Zimbabwe
+      - Afghanistan
+      - Åland Islands
+      - Albania
+      - Algeria
+      - American Samoa
+      - Andorra
+      - Angola
+      - Anguilla
+      - Antarctica
+      - Antigua and Barbuda
+      - Argentina
+      - Armenia
+      - Aruba
+      - Australia
+      - Austria
+      - Azerbaijan
+      - Bahamas
+      - Bahrain
+      - Bangladesh
+      - Barbados
+      - Belarus
+      - Belgium
+      - Belize
+      - Benin
+      - Bermuda
+      - Bhutan
+      - Bolivia
+      - Bonaire, Sint Eustatius and Saba
+      - Bosnia and Herzegovina
+      - Botswana
+      - Bouvet Island
+      - Brazil
+      - British Indian Ocean Territory
+      - Brunei
+      - Bulgaria
+      - Burkina Faso
+      - Burundi
+      - Cabo Verde
+      - Cambodia
+      - Cameroon
+      - Canada
+      - Cayman Islands
+      - Central African Republic
+      - Chad
+      - Chile
+      - China
+      - Christmas Island
+      - Cocos (Keeling) Islands
+      - Colombia
+      - Comoros
+      - Congo
+      - Congo (the Democratic Republic of the)
+      - Cook Islands
+      - Costa Rica
+      - Côte d'Ivoire
+      - Croatia
+      - Cuba
+      - Curaçao
+      - Cyprus
+      - Czechia
+      - Denmark
+      - Djibouti
+      - Dominica
+      - Dominican Republic
+      - Ecuador
+      - Egypt
+      - El Salvador
+      - Equatorial Guinea
+      - Eritrea
+      - Estonia
+      - Eswatini
+      - Ethiopia
+      - Falkland Islands (Malvinas)
+      - Faroe Islands
+      - Fiji
+      - Finland
+      - France
+      - French Guiana
+      - French Polynesia
+      - French Southern Territories
+      - Gabon
+      - Gambia
+      - Georgia
+      - Germany
+      - Ghana
+      - Gibraltar
+      - Greece
+      - Greenland
+      - Grenada
+      - Guadeloupe
+      - Guam
+      - Guatemala
+      - Guernsey
+      - Guinea
+      - Guinea-Bissau
+      - Guyana
+      - Haiti
+      - Heard Island and McDonald Islands
+      - Holy See
+      - Honduras
+      - Hong Kong
+      - Hungary
+      - Iceland
+      - India
+      - Indonesia
+      - Iran
+      - Iraq
+      - Ireland
+      - Isle of Man
+      - Israel
+      - Italy
+      - Jamaica
+      - Japan
+      - Jersey
+      - Jordan
+      - Kazakhstan
+      - Kenya
+      - Kiribati
+      - Kuwait
+      - Kyrgyzstan
+      - Laos
+      - Latvia
+      - Lebanon
+      - Lesotho
+      - Liberia
+      - Libya
+      - Liechtenstein
+      - Lithuania
+      - Luxembourg
+      - Macao
+      - Madagascar
+      - Malawi
+      - Malaysia
+      - Maldives
+      - Mali
+      - Malta
+      - Marshall Islands
+      - Martinique
+      - Mauritania
+      - Mauritius
+      - Mayotte
+      - Mexico
+      - Micronesia
+      - Moldova
+      - Monaco
+      - Mongolia
+      - Montenegro
+      - Montserrat
+      - Morocco
+      - Mozambique
+      - Myanmar
+      - Namibia
+      - Nauru
+      - Nepal
+      - Netherlands
+      - New Caledonia
+      - New Zealand
+      - Nicaragua
+      - Niger
+      - Nigeria
+      - Niue
+      - Norfolk Island
+      - North Korea
+      - North Macedonia
+      - Northern Mariana Islands
+      - Norway
+      - Oman
+      - Pakistan
+      - Palau
+      - Palestine, State of
+      - Panama
+      - Papua New Guinea
+      - Paraguay
+      - Peru
+      - Philippines
+      - Pitcairn
+      - Poland
+      - Portugal
+      - Puerto Rico
+      - Qatar
+      - Réunion
+      - Romania
+      - Russia
+      - Rwanda
+      - Saint Barthélemy
+      - Saint Helena, Ascension and Tristan da Cunha
+      - Saint Kitts and Nevis
+      - Saint Lucia
+      - Saint Martin (French part)
+      - Saint Pierre and Miquelon
+      - Saint Vincent and the Grenadines
+      - Samoa
+      - San Marino
+      - Sao Tome and Principe
+      - Saudi Arabia
+      - Senegal
+      - Serbia
+      - Seychelles
+      - Sierra Leone
+      - Singapore
+      - Sint Maarten (Dutch part)
+      - Slovakia
+      - Slovenia
+      - Solomon Islands
+      - Somalia
+      - South Africa
+      - South Georgia and the South Sandwich Islands
+      - South Korea
+      - South Sudan
+      - Spain
+      - Sri Lanka
+      - Sudan
+      - Suriname
+      - Svalbard and Jan Mayen
+      - Sweden
+      - Switzerland
+      - Syria
+      - Taiwan
+      - Tajikistan
+      - Tanzania
+      - Thailand
+      - Timor-Leste
+      - Togo
+      - Tokelau
+      - Tonga
+      - Trinidad and Tobago
+      - Tunisia
+      - Türkiye
+      - Turkmenistan
+      - Turks and Caicos Islands
+      - Tuvalu
+      - Uganda
+      - Ukraine
+      - United Arab Emirates
+      - United Kingdom
+      - United States Minor Outlying Islands
+      - United States of America
+      - Uruguay
+      - Uzbekistan
+      - Vanuatu
+      - Venezuela
+      - Vietnam
+      - Virgin Islands (British)
+      - Virgin Islands (U.S.)
+      - Wallis and Futuna
+      - Western Sahara
+      - Yemen
+      - Zambia
+      - Zimbabwe
     CreateBasketWithProductsRequest:
       type: object
       description: Serializer for creating a basket with products. (For OpenAPI spec.)
@@ -1474,17 +1468,17 @@ components:
         skus:
           type: array
           items:
-            $ref: "#/components/schemas/CreateBasketWithProductsSkuRequest"
+            $ref: '#/components/schemas/CreateBasketWithProductsSkuRequest'
         checkout:
           type: boolean
         discount_code:
           type: string
           minLength: 1
       required:
-        - checkout
-        - discount_code
-        - skus
-        - system_slug
+      - checkout
+      - discount_code
+      - skus
+      - system_slug
     CreateBasketWithProductsSkuRequest:
       type: object
       description: Defines the schema for a SKU in the CreateBasketWithProductsSerializer.
@@ -1496,12 +1490,11 @@ components:
           type: integer
           minimum: 1
       required:
-        - quantity
-        - sku
+      - quantity
+      - sku
     CyberSourceCheckout:
       type: object
-      description:
-        Really basic serializer for the payload that we need to send to
+      description: Really basic serializer for the payload that we need to send to
         CyberSource.
       properties:
         payload:
@@ -1512,9 +1505,9 @@ components:
         method:
           type: string
       required:
-        - method
-        - payload
-        - url
+      - method
+      - payload
+      - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -1532,8 +1525,8 @@ components:
         payment_type:
           nullable: true
           oneOf:
-            - $ref: "#/components/schemas/PaymentTypeEnum"
-            - $ref: "#/components/schemas/NullEnum"
+          - $ref: '#/components/schemas/PaymentTypeEnum'
+          - $ref: '#/components/schemas/NullEnum'
         max_redemptions:
           type: integer
           maximum: 2147483647
@@ -1543,48 +1536,46 @@ components:
           type: string
           format: date-time
           nullable: true
-          description:
-            If set, this discount code will not be redeemable before this
+          description: If set, this discount code will not be redeemable before this
             date.
         expiration_date:
           type: string
           format: date-time
           nullable: true
-          description:
-            If set, this discount code will not be redeemable after this
+          description: If set, this discount code will not be redeemable after this
             date.
         integrated_system:
-          $ref: "#/components/schemas/IntegratedSystem"
+          $ref: '#/components/schemas/IntegratedSystem'
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
         assigned_users:
           type: array
           items:
-            $ref: "#/components/schemas/User"
+            $ref: '#/components/schemas/User'
         company:
-          $ref: "#/components/schemas/Company"
+          $ref: '#/components/schemas/Company'
       required:
-        - amount
-        - assigned_users
-        - company
-        - discount_code
-        - id
-        - integrated_system
-        - product
+      - amount
+      - assigned_users
+      - company
+      - discount_code
+      - id
+      - integrated_system
+      - product
     DiscountTypeEnum:
       enum:
-        - percent-off
-        - dollars-off
-        - fixed-price
+      - percent-off
+      - dollars-off
+      - fixed-price
       type: string
       description: |-
         * `percent-off` - percent-off
         * `dollars-off` - dollars-off
         * `fixed-price` - fixed-price
       x-enum-descriptions:
-        - percent-off
-        - dollars-off
-        - fixed-price
+      - percent-off
+      - dollars-off
+      - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1602,8 +1593,8 @@ components:
         description:
           type: string
       required:
-        - id
-        - name
+      - id
+      - name
     IntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1619,7 +1610,7 @@ components:
         description:
           type: string
       required:
-        - name
+      - name
     Line:
       type: object
       description: Serializes a line item for an order.
@@ -1644,17 +1635,17 @@ components:
           format: decimal
           pattern: ^-?\d{0,7}(?:\.\d{0,2})?$
         product:
-          $ref: "#/components/schemas/Product"
+          $ref: '#/components/schemas/Product'
       required:
-        - id
-        - item_description
-        - product
-        - quantity
-        - total_price
-        - unit_price
+      - id
+      - item_description
+      - product
+      - quantity
+      - total_price
+      - unit_price
     NullEnum:
       enum:
-        - null
+      - null
     OrderHistory:
       type: object
       description: Serializer for order history.
@@ -1663,7 +1654,7 @@ components:
           type: integer
           readOnly: true
         state:
-          $ref: "#/components/schemas/StateEnum"
+          $ref: '#/components/schemas/StateEnum'
         reference_number:
           type: string
           maxLength: 255
@@ -1676,7 +1667,7 @@ components:
         lines:
           type: array
           items:
-            $ref: "#/components/schemas/Line"
+            $ref: '#/components/schemas/Line'
         created_on:
           type: string
           format: date-time
@@ -1686,17 +1677,17 @@ components:
           format: date-time
           readOnly: true
       required:
-        - created_on
-        - id
-        - lines
-        - purchaser
-        - total_price_paid
-        - updated_on
+      - created_on
+      - id
+      - lines
+      - purchaser
+      - total_price_paid
+      - updated_on
     PaginatedBasketWithProductList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1714,12 +1705,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/BasketWithProduct"
+            $ref: '#/components/schemas/BasketWithProduct'
     PaginatedIntegratedSystemList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1737,12 +1728,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/IntegratedSystem"
+            $ref: '#/components/schemas/IntegratedSystem'
     PaginatedOrderHistoryList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1760,12 +1751,12 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/OrderHistory"
+            $ref: '#/components/schemas/OrderHistory'
     PaginatedProductList:
       type: object
       required:
-        - count
-        - results
+      - count
+      - results
       properties:
         count:
           type: integer
@@ -1783,7 +1774,7 @@ components:
         results:
           type: array
           items:
-            $ref: "#/components/schemas/Product"
+            $ref: '#/components/schemas/Product'
     PatchedIntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1829,19 +1820,18 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
     PaymentTypeEnum:
       enum:
-        - marketing
-        - sales
-        - financial-assistance
-        - customer-support
-        - staff
-        - legacy
-        - credit_card
-        - purchase_order
+      - marketing
+      - sales
+      - financial-assistance
+      - customer-support
+      - staff
+      - legacy
+      - credit_card
+      - purchase_order
       type: string
       description: |-
         * `marketing` - marketing
@@ -1853,14 +1843,14 @@ components:
         * `credit_card` - credit_card
         * `purchase_order` - purchase_order
       x-enum-descriptions:
-        - marketing
-        - sales
-        - financial-assistance
-        - customer-support
-        - staff
-        - legacy
-        - credit_card
-        - purchase_order
+      - marketing
+      - sales
+      - financial-assistance
+      - customer-support
+      - staff
+      - legacy
+      - credit_card
+      - purchase_order
     Product:
       type: object
       description: Serializer for Product model.
@@ -1895,17 +1885,16 @@ components:
           readOnly: true
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
       required:
-        - deleted_by_cascade
-        - description
-        - id
-        - name
-        - price
-        - sku
-        - system
+      - deleted_by_cascade
+      - description
+      - id
+      - name
+      - price
+      - sku
+      - system
     ProductRequest:
       type: object
       description: Serializer for Product model.
@@ -1937,15 +1926,14 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description:
-            Image metadata including URL, alt text, and description (in
+          description: Image metadata including URL, alt text, and description (in
             JSON).
       required:
-        - description
-        - name
-        - price
-        - sku
-        - system
+      - description
+      - name
+      - price
+      - sku
+      - system
     SimpleDiscount:
       type: object
       description: Simpler serializer for discounts.
@@ -1961,7 +1949,7 @@ components:
           format: decimal
           pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
         discount_type:
-          $ref: "#/components/schemas/DiscountTypeEnum"
+          $ref: '#/components/schemas/DiscountTypeEnum'
         formatted_discount_amount:
           type: string
           description: |-
@@ -1970,20 +1958,20 @@ components:
             This quantizes percent discounts to whole numbers. This is probably fine.
           readOnly: true
       required:
-        - amount
-        - discount_code
-        - discount_type
-        - formatted_discount_amount
-        - id
+      - amount
+      - discount_code
+      - discount_type
+      - formatted_discount_amount
+      - id
     StateEnum:
       enum:
-        - pending
-        - fulfilled
-        - canceled
-        - refunded
-        - declined
-        - errored
-        - review
+      - pending
+      - fulfilled
+      - canceled
+      - refunded
+      - declined
+      - errored
+      - review
       type: string
       description: |-
         * `pending` - Pending
@@ -1994,13 +1982,13 @@ components:
         * `errored` - Errored
         * `review` - Review
       x-enum-descriptions:
-        - Pending
-        - Fulfilled
-        - Canceled
-        - Refunded
-        - Declined
-        - Errored
-        - Review
+      - Pending
+      - Fulfilled
+      - Canceled
+      - Refunded
+      - Declined
+      - Errored
+      - Review
     TaxRate:
       type: object
       description: TaxRate model serializer
@@ -2009,7 +1997,7 @@ components:
           type: integer
           readOnly: true
         country_code:
-          $ref: "#/components/schemas/CountryCodeEnum"
+          $ref: '#/components/schemas/CountryCodeEnum'
         tax_rate:
           type: string
           format: decimal
@@ -2018,8 +2006,8 @@ components:
           type: string
           maxLength: 100
       required:
-        - country_code
-        - id
+      - country_code
+      - id
     User:
       type: object
       description: Serializer for User model.
@@ -2029,8 +2017,7 @@ components:
           readOnly: true
         username:
           type: string
-          description:
-            Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
@@ -2046,5 +2033,5 @@ components:
           type: string
           maxLength: 150
       required:
-        - id
-        - username
+      - id
+      - username

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9,440 +9,444 @@ paths:
       operationId: meta_integrated_system_list
       description: Viewset for IntegratedSystem model.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedIntegratedSystemList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedIntegratedSystemList"
+          description: ""
     post:
       operationId: meta_integrated_system_create
       description: Viewset for IntegratedSystem model.
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
         required: true
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
   /api/v0/meta/integrated_system/{id}/:
     get:
       operationId: meta_integrated_system_retrieve
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     put:
       operationId: meta_integrated_system_update
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
         required: true
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     patch:
       operationId: meta_integrated_system_partial_update
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     delete:
       operationId: meta_integrated_system_destroy
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/meta/product/:
     get:
       operationId: meta_product_list
       description: Viewset for Product model.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: system__slug
-        schema:
-          type: string
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - in: query
+          name: name
+          schema:
+            type: string
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
+        - in: query
+          name: system__slug
+          schema:
+            type: string
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedProductList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedProductList"
+          description: ""
     post:
       operationId: meta_product_create
       description: Viewset for Product model.
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
         required: true
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
   /api/v0/meta/product/{id}/:
     get:
       operationId: meta_product_retrieve
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     put:
       operationId: meta_product_update
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
         required: true
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     patch:
       operationId: meta_product_partial_update
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     delete:
       operationId: meta_product_destroy
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/meta/product/preload/{system_slug}/{sku}/:
     get:
       operationId: meta_product_preload_retrieve
-      description: Pre-loads the product metadata for a given SKU, even if the SKU
+      description:
+        Pre-loads the product metadata for a given SKU, even if the SKU
         doesn't exist yet.
       parameters:
-      - in: path
-        name: sku
-        schema:
-          type: string
-          pattern: ^[^/]+$
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-          pattern: ^[^/]+$
-        required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+            pattern: ^[^/]+$
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+            pattern: ^[^/]+$
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
   /api/v0/payments/baskets/:
     get:
       operationId: payments_baskets_list
       description: Retrives the current user's baskets, one per system.
       parameters:
-      - in: query
-        name: integrated_system
-        schema:
-          type: integer
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - in: query
+          name: integrated_system
+          schema:
+            type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedBasketWithProductList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedBasketWithProductList"
+          description: ""
   /api/v0/payments/baskets/{id}/:
     get:
       operationId: payments_baskets_retrieve
       description: Retrieve a basket for the current user.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/add_discount/{system_slug}/:
     post:
       operationId: payments_baskets_add_discount_create
-      description: Creates or updates a basket for the current user, adding the discount
+      description:
+        Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
-      - in: query
-        name: discount_code
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: query
+          name: discount_code
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/clear/{system_slug}/:
     delete:
       operationId: payments_baskets_clear_destroy
       description: Clears the basket for the current user.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/:
     post:
       operationId: payments_baskets_create_from_product_create
-      description: Creates or updates a basket for the current user, adding the selected
+      description:
+        Creates or updates a basket for the current user, adding the selected
         product.
       parameters:
-      - in: path
-        name: sku
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
                 $ref: '#/components/schemas/BasketWithProduct'
@@ -469,35 +473,45 @@ paths:
 =======
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
+=======
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
   /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/:
     post:
-      operationId: payments_baskets_create_from_product_create_2
-      description: Creates or updates a basket for the current user, adding the selected
-        product.
+      operationId: create_basket_from_product_with_discount
+      description:
+        Creates or updates a basket for the current user, adding the selected
+        product and discount.
       parameters:
-      - in: path
-        name: discount_code
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: sku
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: discount_code
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
+<<<<<<< HEAD
       - payments
 >>>>>>> b889362 (updating openapi spec)
+=======
+        - payments
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
+<<<<<<< HEAD
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
 <<<<<<< HEAD
@@ -507,118 +521,123 @@ paths:
 >>>>>>> 27bdec7 (Adding base stuff for product add with discount)
 =======
 >>>>>>> b889362 (updating openapi spec)
+=======
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
   /api/v0/payments/baskets/for_system/{system_slug}/:
     get:
       operationId: payments_baskets_for_system_retrieve
       description: Returns or creates a basket for the current user and system.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/checkout/{system_slug}/:
     post:
       operationId: payments_checkout_create
-      description: Generates and returns the form payload for the current basket for
+      description:
+        Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CyberSourceCheckout'
-          description: ''
+                $ref: "#/components/schemas/CyberSourceCheckout"
+          description: ""
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create
       description: Create a discount.
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Discount'
-          description: ''
+                $ref: "#/components/schemas/Discount"
+          description: ""
   /api/v0/payments/orders/history/:
     get:
       operationId: payments_orders_history_list
       description: Retrives the current user's completed orders.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedOrderHistoryList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedOrderHistoryList"
+          description: ""
   /api/v0/payments/orders/history/{id}/:
     get:
       operationId: payments_orders_history_retrieve
       description: Retrieve a completed order for the current user.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderHistory'
-          description: ''
+                $ref: "#/components/schemas/OrderHistory"
+          description: ""
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
       description: User retrieve and update viewsets for the current user
       tags:
-      - users
+        - users
       security:
-      - {}
+        - {}
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
-          description: ''
+                $ref: "#/components/schemas/User"
+          description: ""
 components:
   schemas:
     BasketItemWithProduct:
@@ -626,7 +645,7 @@ components:
       description: Basket item model serializer with product information
       properties:
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
         id:
           type: integer
           readOnly: true
@@ -650,14 +669,14 @@ components:
           minimum: 0
         discount_applied:
           allOf:
-          - $ref: '#/components/schemas/SimpleDiscount'
+            - $ref: "#/components/schemas/SimpleDiscount"
           readOnly: true
       required:
-      - discount_applied
-      - discounted_price
-      - id
-      - price
-      - product
+        - discount_applied
+        - discounted_price
+        - id
+        - price
+        - product
     BasketWithProduct:
       type: object
       description: Basket model serializer with items and products
@@ -668,11 +687,11 @@ components:
         user:
           type: integer
         integrated_system:
-          $ref: '#/components/schemas/IntegratedSystem'
+          $ref: "#/components/schemas/IntegratedSystem"
         basket_items:
           type: array
           items:
-            $ref: '#/components/schemas/BasketItemWithProduct'
+            $ref: "#/components/schemas/BasketItemWithProduct"
         subtotal:
           type: number
           format: double
@@ -684,21 +703,21 @@ components:
           description: Get the tax for the basket
           readOnly: true
         tax_rate:
-          $ref: '#/components/schemas/TaxRate'
+          $ref: "#/components/schemas/TaxRate"
         total_price:
           type: number
           format: double
           description: Get the total price for the basket
           readOnly: true
       required:
-      - basket_items
-      - id
-      - integrated_system
-      - subtotal
-      - tax
-      - tax_rate
-      - total_price
-      - user
+        - basket_items
+        - id
+        - integrated_system
+        - subtotal
+        - tax
+        - tax_rate
+        - total_price
+        - user
     Company:
       type: object
       description: Serializer for companies.
@@ -710,259 +729,259 @@ components:
           type: string
           maxLength: 255
       required:
-      - id
-      - name
+        - id
+        - name
     CountryCodeEnum:
       enum:
-      - AF
-      - AX
-      - AL
-      - DZ
-      - AS
-      - AD
-      - AO
-      - AI
-      - AQ
-      - AG
-      - AR
-      - AM
-      - AW
-      - AU
-      - AT
-      - AZ
-      - BS
-      - BH
-      - BD
-      - BB
-      - BY
-      - BE
-      - BZ
-      - BJ
-      - BM
-      - BT
-      - BO
-      - BQ
-      - BA
-      - BW
-      - BV
-      - BR
-      - IO
-      - BN
-      - BG
-      - BF
-      - BI
-      - CV
-      - KH
-      - CM
-      - CA
-      - KY
-      - CF
-      - TD
-      - CL
-      - CN
-      - CX
-      - CC
-      - CO
-      - KM
-      - CG
-      - CD
-      - CK
-      - CR
-      - CI
-      - HR
-      - CU
-      - CW
-      - CY
-      - CZ
-      - DK
-      - DJ
-      - DM
-      - DO
-      - EC
-      - EG
-      - SV
-      - GQ
-      - ER
-      - EE
-      - SZ
-      - ET
-      - FK
-      - FO
-      - FJ
-      - FI
-      - FR
-      - GF
-      - PF
-      - TF
-      - GA
-      - GM
-      - GE
-      - DE
-      - GH
-      - GI
-      - GR
-      - GL
-      - GD
-      - GP
-      - GU
-      - GT
-      - GG
-      - GN
-      - GW
-      - GY
-      - HT
-      - HM
-      - VA
-      - HN
-      - HK
-      - HU
-      - IS
-      - IN
-      - ID
-      - IR
-      - IQ
-      - IE
-      - IM
-      - IL
-      - IT
-      - JM
-      - JP
-      - JE
-      - JO
-      - KZ
-      - KE
-      - KI
-      - KW
-      - KG
-      - LA
-      - LV
-      - LB
-      - LS
-      - LR
-      - LY
-      - LI
-      - LT
-      - LU
-      - MO
-      - MG
-      - MW
-      - MY
-      - MV
-      - ML
-      - MT
-      - MH
-      - MQ
-      - MR
-      - MU
-      - YT
-      - MX
-      - FM
-      - MD
-      - MC
-      - MN
-      - ME
-      - MS
-      - MA
-      - MZ
-      - MM
-      - NA
-      - NR
-      - NP
-      - NL
-      - NC
-      - NZ
-      - NI
-      - NE
-      - NG
-      - NU
-      - NF
-      - KP
-      - MK
-      - MP
-      - 'NO'
-      - OM
-      - PK
-      - PW
-      - PS
-      - PA
-      - PG
-      - PY
-      - PE
-      - PH
-      - PN
-      - PL
-      - PT
-      - PR
-      - QA
-      - RE
-      - RO
-      - RU
-      - RW
-      - BL
-      - SH
-      - KN
-      - LC
-      - MF
-      - PM
-      - VC
-      - WS
-      - SM
-      - ST
-      - SA
-      - SN
-      - RS
-      - SC
-      - SL
-      - SG
-      - SX
-      - SK
-      - SI
-      - SB
-      - SO
-      - ZA
-      - GS
-      - KR
-      - SS
-      - ES
-      - LK
-      - SD
-      - SR
-      - SJ
-      - SE
-      - CH
-      - SY
-      - TW
-      - TJ
-      - TZ
-      - TH
-      - TL
-      - TG
-      - TK
-      - TO
-      - TT
-      - TN
-      - TR
-      - TM
-      - TC
-      - TV
-      - UG
-      - UA
-      - AE
-      - GB
-      - UM
-      - US
-      - UY
-      - UZ
-      - VU
-      - VE
-      - VN
-      - VG
-      - VI
-      - WF
-      - EH
-      - YE
-      - ZM
-      - ZW
+        - AF
+        - AX
+        - AL
+        - DZ
+        - AS
+        - AD
+        - AO
+        - AI
+        - AQ
+        - AG
+        - AR
+        - AM
+        - AW
+        - AU
+        - AT
+        - AZ
+        - BS
+        - BH
+        - BD
+        - BB
+        - BY
+        - BE
+        - BZ
+        - BJ
+        - BM
+        - BT
+        - BO
+        - BQ
+        - BA
+        - BW
+        - BV
+        - BR
+        - IO
+        - BN
+        - BG
+        - BF
+        - BI
+        - CV
+        - KH
+        - CM
+        - CA
+        - KY
+        - CF
+        - TD
+        - CL
+        - CN
+        - CX
+        - CC
+        - CO
+        - KM
+        - CG
+        - CD
+        - CK
+        - CR
+        - CI
+        - HR
+        - CU
+        - CW
+        - CY
+        - CZ
+        - DK
+        - DJ
+        - DM
+        - DO
+        - EC
+        - EG
+        - SV
+        - GQ
+        - ER
+        - EE
+        - SZ
+        - ET
+        - FK
+        - FO
+        - FJ
+        - FI
+        - FR
+        - GF
+        - PF
+        - TF
+        - GA
+        - GM
+        - GE
+        - DE
+        - GH
+        - GI
+        - GR
+        - GL
+        - GD
+        - GP
+        - GU
+        - GT
+        - GG
+        - GN
+        - GW
+        - GY
+        - HT
+        - HM
+        - VA
+        - HN
+        - HK
+        - HU
+        - IS
+        - IN
+        - ID
+        - IR
+        - IQ
+        - IE
+        - IM
+        - IL
+        - IT
+        - JM
+        - JP
+        - JE
+        - JO
+        - KZ
+        - KE
+        - KI
+        - KW
+        - KG
+        - LA
+        - LV
+        - LB
+        - LS
+        - LR
+        - LY
+        - LI
+        - LT
+        - LU
+        - MO
+        - MG
+        - MW
+        - MY
+        - MV
+        - ML
+        - MT
+        - MH
+        - MQ
+        - MR
+        - MU
+        - YT
+        - MX
+        - FM
+        - MD
+        - MC
+        - MN
+        - ME
+        - MS
+        - MA
+        - MZ
+        - MM
+        - NA
+        - NR
+        - NP
+        - NL
+        - NC
+        - NZ
+        - NI
+        - NE
+        - NG
+        - NU
+        - NF
+        - KP
+        - MK
+        - MP
+        - "NO"
+        - OM
+        - PK
+        - PW
+        - PS
+        - PA
+        - PG
+        - PY
+        - PE
+        - PH
+        - PN
+        - PL
+        - PT
+        - PR
+        - QA
+        - RE
+        - RO
+        - RU
+        - RW
+        - BL
+        - SH
+        - KN
+        - LC
+        - MF
+        - PM
+        - VC
+        - WS
+        - SM
+        - ST
+        - SA
+        - SN
+        - RS
+        - SC
+        - SL
+        - SG
+        - SX
+        - SK
+        - SI
+        - SB
+        - SO
+        - ZA
+        - GS
+        - KR
+        - SS
+        - ES
+        - LK
+        - SD
+        - SR
+        - SJ
+        - SE
+        - CH
+        - SY
+        - TW
+        - TJ
+        - TZ
+        - TH
+        - TL
+        - TG
+        - TK
+        - TO
+        - TT
+        - TN
+        - TR
+        - TM
+        - TC
+        - TV
+        - UG
+        - UA
+        - AE
+        - GB
+        - UM
+        - US
+        - UY
+        - UZ
+        - VU
+        - VE
+        - VN
+        - VG
+        - VI
+        - WF
+        - EH
+        - YE
+        - ZM
+        - ZW
       type: string
       description: |-
         * `AF` - Afghanistan
@@ -1215,6 +1234,7 @@ components:
         * `ZM` - Zambia
         * `ZW` - Zimbabwe
       x-enum-descriptions:
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 =======
@@ -1504,6 +1524,8 @@ components:
       - quantity
       - sku
 =======
+=======
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
         - Afghanistan
         - Åland Islands
         - Albania
@@ -1753,12 +1775,16 @@ components:
         - Yemen
         - Zambia
         - Zimbabwe
+<<<<<<< HEAD
 >>>>>>> 27bdec7 (Adding base stuff for product add with discount)
 =======
 >>>>>>> b889362 (updating openapi spec)
+=======
+>>>>>>> 85627b5 (reworking some of this to make OpenAPI spec generation happy)
     CyberSourceCheckout:
       type: object
-      description: Really basic serializer for the payload that we need to send to
+      description:
+        Really basic serializer for the payload that we need to send to
         CyberSource.
       properties:
         payload:
@@ -1769,9 +1795,9 @@ components:
         method:
           type: string
       required:
-      - method
-      - payload
-      - url
+        - method
+        - payload
+        - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -1789,8 +1815,8 @@ components:
         payment_type:
           nullable: true
           oneOf:
-          - $ref: '#/components/schemas/PaymentTypeEnum'
-          - $ref: '#/components/schemas/NullEnum'
+            - $ref: "#/components/schemas/PaymentTypeEnum"
+            - $ref: "#/components/schemas/NullEnum"
         max_redemptions:
           type: integer
           maximum: 2147483647
@@ -1800,46 +1826,48 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: If set, this discount code will not be redeemable before this
+          description:
+            If set, this discount code will not be redeemable before this
             date.
         expiration_date:
           type: string
           format: date-time
           nullable: true
-          description: If set, this discount code will not be redeemable after this
+          description:
+            If set, this discount code will not be redeemable after this
             date.
         integrated_system:
-          $ref: '#/components/schemas/IntegratedSystem'
+          $ref: "#/components/schemas/IntegratedSystem"
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
         assigned_users:
           type: array
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         company:
-          $ref: '#/components/schemas/Company'
+          $ref: "#/components/schemas/Company"
       required:
-      - amount
-      - assigned_users
-      - company
-      - discount_code
-      - id
-      - integrated_system
-      - product
+        - amount
+        - assigned_users
+        - company
+        - discount_code
+        - id
+        - integrated_system
+        - product
     DiscountTypeEnum:
       enum:
-      - percent-off
-      - dollars-off
-      - fixed-price
+        - percent-off
+        - dollars-off
+        - fixed-price
       type: string
       description: |-
         * `percent-off` - percent-off
         * `dollars-off` - dollars-off
         * `fixed-price` - fixed-price
       x-enum-descriptions:
-      - percent-off
-      - dollars-off
-      - fixed-price
+        - percent-off
+        - dollars-off
+        - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1857,8 +1885,8 @@ components:
         description:
           type: string
       required:
-      - id
-      - name
+        - id
+        - name
     IntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1874,7 +1902,7 @@ components:
         description:
           type: string
       required:
-      - name
+        - name
     Line:
       type: object
       description: Serializes a line item for an order.
@@ -1899,17 +1927,17 @@ components:
           format: decimal
           pattern: ^-?\d{0,7}(?:\.\d{0,2})?$
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
       required:
-      - id
-      - item_description
-      - product
-      - quantity
-      - total_price
-      - unit_price
+        - id
+        - item_description
+        - product
+        - quantity
+        - total_price
+        - unit_price
     NullEnum:
       enum:
-      - null
+        - null
     OrderHistory:
       type: object
       description: Serializer for order history.
@@ -1918,7 +1946,7 @@ components:
           type: integer
           readOnly: true
         state:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         reference_number:
           type: string
           maxLength: 255
@@ -1931,7 +1959,7 @@ components:
         lines:
           type: array
           items:
-            $ref: '#/components/schemas/Line'
+            $ref: "#/components/schemas/Line"
         created_on:
           type: string
           format: date-time
@@ -1941,17 +1969,17 @@ components:
           format: date-time
           readOnly: true
       required:
-      - created_on
-      - id
-      - lines
-      - purchaser
-      - total_price_paid
-      - updated_on
+        - created_on
+        - id
+        - lines
+        - purchaser
+        - total_price_paid
+        - updated_on
     PaginatedBasketWithProductList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1969,12 +1997,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/BasketWithProduct'
+            $ref: "#/components/schemas/BasketWithProduct"
     PaginatedIntegratedSystemList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1992,12 +2020,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/IntegratedSystem'
+            $ref: "#/components/schemas/IntegratedSystem"
     PaginatedOrderHistoryList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -2015,12 +2043,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/OrderHistory'
+            $ref: "#/components/schemas/OrderHistory"
     PaginatedProductList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -2038,7 +2066,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Product'
+            $ref: "#/components/schemas/Product"
     PatchedIntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -2084,18 +2112,19 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
     PaymentTypeEnum:
       enum:
-      - marketing
-      - sales
-      - financial-assistance
-      - customer-support
-      - staff
-      - legacy
-      - credit_card
-      - purchase_order
+        - marketing
+        - sales
+        - financial-assistance
+        - customer-support
+        - staff
+        - legacy
+        - credit_card
+        - purchase_order
       type: string
       description: |-
         * `marketing` - marketing
@@ -2107,14 +2136,14 @@ components:
         * `credit_card` - credit_card
         * `purchase_order` - purchase_order
       x-enum-descriptions:
-      - marketing
-      - sales
-      - financial-assistance
-      - customer-support
-      - staff
-      - legacy
-      - credit_card
-      - purchase_order
+        - marketing
+        - sales
+        - financial-assistance
+        - customer-support
+        - staff
+        - legacy
+        - credit_card
+        - purchase_order
     Product:
       type: object
       description: Serializer for Product model.
@@ -2149,16 +2178,17 @@ components:
           readOnly: true
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
       required:
-      - deleted_by_cascade
-      - description
-      - id
-      - name
-      - price
-      - sku
-      - system
+        - deleted_by_cascade
+        - description
+        - id
+        - name
+        - price
+        - sku
+        - system
     ProductRequest:
       type: object
       description: Serializer for Product model.
@@ -2190,14 +2220,15 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
       required:
-      - description
-      - name
-      - price
-      - sku
-      - system
+        - description
+        - name
+        - price
+        - sku
+        - system
     SimpleDiscount:
       type: object
       description: Simpler serializer for discounts.
@@ -2213,7 +2244,7 @@ components:
           format: decimal
           pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
         discount_type:
-          $ref: '#/components/schemas/DiscountTypeEnum'
+          $ref: "#/components/schemas/DiscountTypeEnum"
         formatted_discount_amount:
           type: string
           description: |-
@@ -2222,20 +2253,20 @@ components:
             This quantizes percent discounts to whole numbers. This is probably fine.
           readOnly: true
       required:
-      - amount
-      - discount_code
-      - discount_type
-      - formatted_discount_amount
-      - id
+        - amount
+        - discount_code
+        - discount_type
+        - formatted_discount_amount
+        - id
     StateEnum:
       enum:
-      - pending
-      - fulfilled
-      - canceled
-      - refunded
-      - declined
-      - errored
-      - review
+        - pending
+        - fulfilled
+        - canceled
+        - refunded
+        - declined
+        - errored
+        - review
       type: string
       description: |-
         * `pending` - Pending
@@ -2246,13 +2277,13 @@ components:
         * `errored` - Errored
         * `review` - Review
       x-enum-descriptions:
-      - Pending
-      - Fulfilled
-      - Canceled
-      - Refunded
-      - Declined
-      - Errored
-      - Review
+        - Pending
+        - Fulfilled
+        - Canceled
+        - Refunded
+        - Declined
+        - Errored
+        - Review
     TaxRate:
       type: object
       description: TaxRate model serializer
@@ -2261,7 +2292,7 @@ components:
           type: integer
           readOnly: true
         country_code:
-          $ref: '#/components/schemas/CountryCodeEnum'
+          $ref: "#/components/schemas/CountryCodeEnum"
         tax_rate:
           type: string
           format: decimal
@@ -2270,8 +2301,8 @@ components:
           type: string
           maxLength: 100
       required:
-      - country_code
-      - id
+        - country_code
+        - id
     User:
       type: object
       description: Serializer for User model.
@@ -2281,7 +2312,8 @@ components:
           readOnly: true
         username:
           type: string
-          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+          description:
+            Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
@@ -2297,5 +2329,5 @@ components:
           type: string
           maxLength: 150
       required:
-      - id
-      - username
+        - id
+        - username

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -9,440 +9,449 @@ paths:
       operationId: meta_integrated_system_list
       description: Viewset for IntegratedSystem model.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedIntegratedSystemList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedIntegratedSystemList"
+          description: ""
     post:
       operationId: meta_integrated_system_create
       description: Viewset for IntegratedSystem model.
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
         required: true
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
   /api/v0/meta/integrated_system/{id}/:
     get:
       operationId: meta_integrated_system_retrieve
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     put:
       operationId: meta_integrated_system_update
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/IntegratedSystemRequest'
+              $ref: "#/components/schemas/IntegratedSystemRequest"
         required: true
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     patch:
       operationId: meta_integrated_system_partial_update
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedIntegratedSystemRequest'
+              $ref: "#/components/schemas/PatchedIntegratedSystemRequest"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IntegratedSystem'
-          description: ''
+                $ref: "#/components/schemas/IntegratedSystem"
+          description: ""
     delete:
       operationId: meta_integrated_system_destroy
       description: Viewset for IntegratedSystem model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this integrated system.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this integrated system.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/meta/product/:
     get:
       operationId: meta_product_list
       description: Viewset for Product model.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: name
-        schema:
-          type: string
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: system__slug
-        schema:
-          type: string
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - in: query
+          name: name
+          schema:
+            type: string
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
+        - in: query
+          name: system__slug
+          schema:
+            type: string
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedProductList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedProductList"
+          description: ""
     post:
       operationId: meta_product_create
       description: Viewset for Product model.
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
         required: true
       responses:
-        '201':
+        "201":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
   /api/v0/meta/product/{id}/:
     get:
       operationId: meta_product_retrieve
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     put:
       operationId: meta_product_update
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ProductRequest'
+              $ref: "#/components/schemas/ProductRequest"
         required: true
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     patch:
       operationId: meta_product_partial_update
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedProductRequest'
+              $ref: "#/components/schemas/PatchedProductRequest"
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
     delete:
       operationId: meta_product_destroy
       description: Viewset for Product model.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this product.
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          description: A unique integer value identifying this product.
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '204':
+        "204":
           description: No response body
   /api/v0/meta/product/preload/{system_slug}/{sku}/:
     get:
       operationId: meta_product_preload_retrieve
-      description: Pre-loads the product metadata for a given SKU, even if the SKU
+      description:
+        Pre-loads the product metadata for a given SKU, even if the SKU
         doesn't exist yet.
       parameters:
-      - in: path
-        name: sku
-        schema:
-          type: string
-          pattern: ^[^/]+$
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-          pattern: ^[^/]+$
-        required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+            pattern: ^[^/]+$
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+            pattern: ^[^/]+$
+          required: true
       tags:
-      - meta
+        - meta
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
-          description: ''
+                $ref: "#/components/schemas/Product"
+          description: ""
   /api/v0/payments/baskets/:
     get:
       operationId: payments_baskets_list
       description: Retrives the current user's baskets, one per system.
       parameters:
-      - in: query
-        name: integrated_system
-        schema:
-          type: integer
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - in: query
+          name: integrated_system
+          schema:
+            type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedBasketWithProductList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedBasketWithProductList"
+          description: ""
   /api/v0/payments/baskets/{id}/:
     get:
       operationId: payments_baskets_retrieve
       description: Retrieve a basket for the current user.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/add_discount/{system_slug}/:
     post:
       operationId: payments_baskets_add_discount_create
-      description: Creates or updates a basket for the current user, adding the discount
+      description:
+        Creates or updates a basket for the current user, adding the discount
         if valid.
       parameters:
-      - in: query
-        name: discount_code
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: query
+          name: discount_code
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/baskets/clear/{system_slug}/:
     delete:
       operationId: payments_baskets_clear_destroy
       description: Clears the basket for the current user.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '204':
+        "204":
           description: No response body
-  /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/:
+  /api/v0/payments/baskets/create_from_product/{system_slug}/{sku}/{discount_code}/:
     post:
       operationId: payments_baskets_create_from_product_create
-      description: Creates or updates a basket for the current user, adding the selected
+      description:
+        Creates or updates a basket for the current user, adding the selected
         product.
       parameters:
-      - in: path
-        name: sku
-        schema:
-          type: string
-        required: true
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: discount_code
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: sku
+          schema:
+            type: string
+          required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
+<<<<<<< HEAD
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
   /api/v0/payments/baskets/create_with_products/:
@@ -471,118 +480,123 @@ paths:
               schema:
                 $ref: '#/components/schemas/BasketWithProduct'
           description: ''
+=======
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
+>>>>>>> 27bdec7 (Adding base stuff for product add with discount)
   /api/v0/payments/baskets/for_system/{system_slug}/:
     get:
       operationId: payments_baskets_for_system_retrieve
       description: Returns or creates a basket for the current user and system.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BasketWithProduct'
-          description: ''
+                $ref: "#/components/schemas/BasketWithProduct"
+          description: ""
   /api/v0/payments/checkout/{system_slug}/:
     post:
       operationId: payments_checkout_create
-      description: Generates and returns the form payload for the current basket for
+      description:
+        Generates and returns the form payload for the current basket for
         the specified system, which can be used to start the checkout process.
       parameters:
-      - in: path
-        name: system_slug
-        schema:
-          type: string
-        required: true
+        - in: path
+          name: system_slug
+          schema:
+            type: string
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CyberSourceCheckout'
-          description: ''
+                $ref: "#/components/schemas/CyberSourceCheckout"
+          description: ""
   /api/v0/payments/discounts/:
     post:
       operationId: payments_discounts_create
       description: Create a discount.
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Discount'
-          description: ''
+                $ref: "#/components/schemas/Discount"
+          description: ""
   /api/v0/payments/orders/history/:
     get:
       operationId: payments_orders_history_list
       description: Retrives the current user's completed orders.
       parameters:
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
+        - name: limit
+          required: false
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+        - name: offset
+          required: false
+          in: query
+          description: The initial index from which to return the results.
+          schema:
+            type: integer
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedOrderHistoryList'
-          description: ''
+                $ref: "#/components/schemas/PaginatedOrderHistoryList"
+          description: ""
   /api/v0/payments/orders/history/{id}/:
     get:
       operationId: payments_orders_history_retrieve
       description: Retrieve a completed order for the current user.
       parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        required: true
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
       tags:
-      - payments
+        - payments
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/OrderHistory'
-          description: ''
+                $ref: "#/components/schemas/OrderHistory"
+          description: ""
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
       description: User retrieve and update viewsets for the current user
       tags:
-      - users
+        - users
       security:
-      - {}
+        - {}
       responses:
-        '200':
+        "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
-          description: ''
+                $ref: "#/components/schemas/User"
+          description: ""
 components:
   schemas:
     BasketItemWithProduct:
@@ -590,7 +604,7 @@ components:
       description: Basket item model serializer with product information
       properties:
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
         id:
           type: integer
           readOnly: true
@@ -614,14 +628,14 @@ components:
           minimum: 0
         discount_applied:
           allOf:
-          - $ref: '#/components/schemas/SimpleDiscount'
+            - $ref: "#/components/schemas/SimpleDiscount"
           readOnly: true
       required:
-      - discount_applied
-      - discounted_price
-      - id
-      - price
-      - product
+        - discount_applied
+        - discounted_price
+        - id
+        - price
+        - product
     BasketWithProduct:
       type: object
       description: Basket model serializer with items and products
@@ -632,11 +646,11 @@ components:
         user:
           type: integer
         integrated_system:
-          $ref: '#/components/schemas/IntegratedSystem'
+          $ref: "#/components/schemas/IntegratedSystem"
         basket_items:
           type: array
           items:
-            $ref: '#/components/schemas/BasketItemWithProduct'
+            $ref: "#/components/schemas/BasketItemWithProduct"
         subtotal:
           type: number
           format: double
@@ -648,21 +662,21 @@ components:
           description: Get the tax for the basket
           readOnly: true
         tax_rate:
-          $ref: '#/components/schemas/TaxRate'
+          $ref: "#/components/schemas/TaxRate"
         total_price:
           type: number
           format: double
           description: Get the total price for the basket
           readOnly: true
       required:
-      - basket_items
-      - id
-      - integrated_system
-      - subtotal
-      - tax
-      - tax_rate
-      - total_price
-      - user
+        - basket_items
+        - id
+        - integrated_system
+        - subtotal
+        - tax
+        - tax_rate
+        - total_price
+        - user
     Company:
       type: object
       description: Serializer for companies.
@@ -674,259 +688,259 @@ components:
           type: string
           maxLength: 255
       required:
-      - id
-      - name
+        - id
+        - name
     CountryCodeEnum:
       enum:
-      - AF
-      - AX
-      - AL
-      - DZ
-      - AS
-      - AD
-      - AO
-      - AI
-      - AQ
-      - AG
-      - AR
-      - AM
-      - AW
-      - AU
-      - AT
-      - AZ
-      - BS
-      - BH
-      - BD
-      - BB
-      - BY
-      - BE
-      - BZ
-      - BJ
-      - BM
-      - BT
-      - BO
-      - BQ
-      - BA
-      - BW
-      - BV
-      - BR
-      - IO
-      - BN
-      - BG
-      - BF
-      - BI
-      - CV
-      - KH
-      - CM
-      - CA
-      - KY
-      - CF
-      - TD
-      - CL
-      - CN
-      - CX
-      - CC
-      - CO
-      - KM
-      - CG
-      - CD
-      - CK
-      - CR
-      - CI
-      - HR
-      - CU
-      - CW
-      - CY
-      - CZ
-      - DK
-      - DJ
-      - DM
-      - DO
-      - EC
-      - EG
-      - SV
-      - GQ
-      - ER
-      - EE
-      - SZ
-      - ET
-      - FK
-      - FO
-      - FJ
-      - FI
-      - FR
-      - GF
-      - PF
-      - TF
-      - GA
-      - GM
-      - GE
-      - DE
-      - GH
-      - GI
-      - GR
-      - GL
-      - GD
-      - GP
-      - GU
-      - GT
-      - GG
-      - GN
-      - GW
-      - GY
-      - HT
-      - HM
-      - VA
-      - HN
-      - HK
-      - HU
-      - IS
-      - IN
-      - ID
-      - IR
-      - IQ
-      - IE
-      - IM
-      - IL
-      - IT
-      - JM
-      - JP
-      - JE
-      - JO
-      - KZ
-      - KE
-      - KI
-      - KW
-      - KG
-      - LA
-      - LV
-      - LB
-      - LS
-      - LR
-      - LY
-      - LI
-      - LT
-      - LU
-      - MO
-      - MG
-      - MW
-      - MY
-      - MV
-      - ML
-      - MT
-      - MH
-      - MQ
-      - MR
-      - MU
-      - YT
-      - MX
-      - FM
-      - MD
-      - MC
-      - MN
-      - ME
-      - MS
-      - MA
-      - MZ
-      - MM
-      - NA
-      - NR
-      - NP
-      - NL
-      - NC
-      - NZ
-      - NI
-      - NE
-      - NG
-      - NU
-      - NF
-      - KP
-      - MK
-      - MP
-      - 'NO'
-      - OM
-      - PK
-      - PW
-      - PS
-      - PA
-      - PG
-      - PY
-      - PE
-      - PH
-      - PN
-      - PL
-      - PT
-      - PR
-      - QA
-      - RE
-      - RO
-      - RU
-      - RW
-      - BL
-      - SH
-      - KN
-      - LC
-      - MF
-      - PM
-      - VC
-      - WS
-      - SM
-      - ST
-      - SA
-      - SN
-      - RS
-      - SC
-      - SL
-      - SG
-      - SX
-      - SK
-      - SI
-      - SB
-      - SO
-      - ZA
-      - GS
-      - KR
-      - SS
-      - ES
-      - LK
-      - SD
-      - SR
-      - SJ
-      - SE
-      - CH
-      - SY
-      - TW
-      - TJ
-      - TZ
-      - TH
-      - TL
-      - TG
-      - TK
-      - TO
-      - TT
-      - TN
-      - TR
-      - TM
-      - TC
-      - TV
-      - UG
-      - UA
-      - AE
-      - GB
-      - UM
-      - US
-      - UY
-      - UZ
-      - VU
-      - VE
-      - VN
-      - VG
-      - VI
-      - WF
-      - EH
-      - YE
-      - ZM
-      - ZW
+        - AF
+        - AX
+        - AL
+        - DZ
+        - AS
+        - AD
+        - AO
+        - AI
+        - AQ
+        - AG
+        - AR
+        - AM
+        - AW
+        - AU
+        - AT
+        - AZ
+        - BS
+        - BH
+        - BD
+        - BB
+        - BY
+        - BE
+        - BZ
+        - BJ
+        - BM
+        - BT
+        - BO
+        - BQ
+        - BA
+        - BW
+        - BV
+        - BR
+        - IO
+        - BN
+        - BG
+        - BF
+        - BI
+        - CV
+        - KH
+        - CM
+        - CA
+        - KY
+        - CF
+        - TD
+        - CL
+        - CN
+        - CX
+        - CC
+        - CO
+        - KM
+        - CG
+        - CD
+        - CK
+        - CR
+        - CI
+        - HR
+        - CU
+        - CW
+        - CY
+        - CZ
+        - DK
+        - DJ
+        - DM
+        - DO
+        - EC
+        - EG
+        - SV
+        - GQ
+        - ER
+        - EE
+        - SZ
+        - ET
+        - FK
+        - FO
+        - FJ
+        - FI
+        - FR
+        - GF
+        - PF
+        - TF
+        - GA
+        - GM
+        - GE
+        - DE
+        - GH
+        - GI
+        - GR
+        - GL
+        - GD
+        - GP
+        - GU
+        - GT
+        - GG
+        - GN
+        - GW
+        - GY
+        - HT
+        - HM
+        - VA
+        - HN
+        - HK
+        - HU
+        - IS
+        - IN
+        - ID
+        - IR
+        - IQ
+        - IE
+        - IM
+        - IL
+        - IT
+        - JM
+        - JP
+        - JE
+        - JO
+        - KZ
+        - KE
+        - KI
+        - KW
+        - KG
+        - LA
+        - LV
+        - LB
+        - LS
+        - LR
+        - LY
+        - LI
+        - LT
+        - LU
+        - MO
+        - MG
+        - MW
+        - MY
+        - MV
+        - ML
+        - MT
+        - MH
+        - MQ
+        - MR
+        - MU
+        - YT
+        - MX
+        - FM
+        - MD
+        - MC
+        - MN
+        - ME
+        - MS
+        - MA
+        - MZ
+        - MM
+        - NA
+        - NR
+        - NP
+        - NL
+        - NC
+        - NZ
+        - NI
+        - NE
+        - NG
+        - NU
+        - NF
+        - KP
+        - MK
+        - MP
+        - "NO"
+        - OM
+        - PK
+        - PW
+        - PS
+        - PA
+        - PG
+        - PY
+        - PE
+        - PH
+        - PN
+        - PL
+        - PT
+        - PR
+        - QA
+        - RE
+        - RO
+        - RU
+        - RW
+        - BL
+        - SH
+        - KN
+        - LC
+        - MF
+        - PM
+        - VC
+        - WS
+        - SM
+        - ST
+        - SA
+        - SN
+        - RS
+        - SC
+        - SL
+        - SG
+        - SX
+        - SK
+        - SI
+        - SB
+        - SO
+        - ZA
+        - GS
+        - KR
+        - SS
+        - ES
+        - LK
+        - SD
+        - SR
+        - SJ
+        - SE
+        - CH
+        - SY
+        - TW
+        - TJ
+        - TZ
+        - TH
+        - TL
+        - TG
+        - TK
+        - TO
+        - TT
+        - TN
+        - TR
+        - TM
+        - TC
+        - TV
+        - UG
+        - UA
+        - AE
+        - GB
+        - UM
+        - US
+        - UY
+        - UZ
+        - VU
+        - VE
+        - VN
+        - VG
+        - VI
+        - WF
+        - EH
+        - YE
+        - ZM
+        - ZW
       type: string
       description: |-
         * `AF` - Afghanistan
@@ -1179,6 +1193,7 @@ components:
         * `ZM` - Zambia
         * `ZW` - Zimbabwe
       x-enum-descriptions:
+<<<<<<< HEAD
       - Afghanistan
       - Åland Islands
       - Albania
@@ -1462,9 +1477,261 @@ components:
       required:
       - quantity
       - sku
+=======
+        - Afghanistan
+        - Åland Islands
+        - Albania
+        - Algeria
+        - American Samoa
+        - Andorra
+        - Angola
+        - Anguilla
+        - Antarctica
+        - Antigua and Barbuda
+        - Argentina
+        - Armenia
+        - Aruba
+        - Australia
+        - Austria
+        - Azerbaijan
+        - Bahamas
+        - Bahrain
+        - Bangladesh
+        - Barbados
+        - Belarus
+        - Belgium
+        - Belize
+        - Benin
+        - Bermuda
+        - Bhutan
+        - Bolivia
+        - Bonaire, Sint Eustatius and Saba
+        - Bosnia and Herzegovina
+        - Botswana
+        - Bouvet Island
+        - Brazil
+        - British Indian Ocean Territory
+        - Brunei
+        - Bulgaria
+        - Burkina Faso
+        - Burundi
+        - Cabo Verde
+        - Cambodia
+        - Cameroon
+        - Canada
+        - Cayman Islands
+        - Central African Republic
+        - Chad
+        - Chile
+        - China
+        - Christmas Island
+        - Cocos (Keeling) Islands
+        - Colombia
+        - Comoros
+        - Congo
+        - Congo (the Democratic Republic of the)
+        - Cook Islands
+        - Costa Rica
+        - Côte d'Ivoire
+        - Croatia
+        - Cuba
+        - Curaçao
+        - Cyprus
+        - Czechia
+        - Denmark
+        - Djibouti
+        - Dominica
+        - Dominican Republic
+        - Ecuador
+        - Egypt
+        - El Salvador
+        - Equatorial Guinea
+        - Eritrea
+        - Estonia
+        - Eswatini
+        - Ethiopia
+        - Falkland Islands (Malvinas)
+        - Faroe Islands
+        - Fiji
+        - Finland
+        - France
+        - French Guiana
+        - French Polynesia
+        - French Southern Territories
+        - Gabon
+        - Gambia
+        - Georgia
+        - Germany
+        - Ghana
+        - Gibraltar
+        - Greece
+        - Greenland
+        - Grenada
+        - Guadeloupe
+        - Guam
+        - Guatemala
+        - Guernsey
+        - Guinea
+        - Guinea-Bissau
+        - Guyana
+        - Haiti
+        - Heard Island and McDonald Islands
+        - Holy See
+        - Honduras
+        - Hong Kong
+        - Hungary
+        - Iceland
+        - India
+        - Indonesia
+        - Iran
+        - Iraq
+        - Ireland
+        - Isle of Man
+        - Israel
+        - Italy
+        - Jamaica
+        - Japan
+        - Jersey
+        - Jordan
+        - Kazakhstan
+        - Kenya
+        - Kiribati
+        - Kuwait
+        - Kyrgyzstan
+        - Laos
+        - Latvia
+        - Lebanon
+        - Lesotho
+        - Liberia
+        - Libya
+        - Liechtenstein
+        - Lithuania
+        - Luxembourg
+        - Macao
+        - Madagascar
+        - Malawi
+        - Malaysia
+        - Maldives
+        - Mali
+        - Malta
+        - Marshall Islands
+        - Martinique
+        - Mauritania
+        - Mauritius
+        - Mayotte
+        - Mexico
+        - Micronesia
+        - Moldova
+        - Monaco
+        - Mongolia
+        - Montenegro
+        - Montserrat
+        - Morocco
+        - Mozambique
+        - Myanmar
+        - Namibia
+        - Nauru
+        - Nepal
+        - Netherlands
+        - New Caledonia
+        - New Zealand
+        - Nicaragua
+        - Niger
+        - Nigeria
+        - Niue
+        - Norfolk Island
+        - North Korea
+        - North Macedonia
+        - Northern Mariana Islands
+        - Norway
+        - Oman
+        - Pakistan
+        - Palau
+        - Palestine, State of
+        - Panama
+        - Papua New Guinea
+        - Paraguay
+        - Peru
+        - Philippines
+        - Pitcairn
+        - Poland
+        - Portugal
+        - Puerto Rico
+        - Qatar
+        - Réunion
+        - Romania
+        - Russia
+        - Rwanda
+        - Saint Barthélemy
+        - Saint Helena, Ascension and Tristan da Cunha
+        - Saint Kitts and Nevis
+        - Saint Lucia
+        - Saint Martin (French part)
+        - Saint Pierre and Miquelon
+        - Saint Vincent and the Grenadines
+        - Samoa
+        - San Marino
+        - Sao Tome and Principe
+        - Saudi Arabia
+        - Senegal
+        - Serbia
+        - Seychelles
+        - Sierra Leone
+        - Singapore
+        - Sint Maarten (Dutch part)
+        - Slovakia
+        - Slovenia
+        - Solomon Islands
+        - Somalia
+        - South Africa
+        - South Georgia and the South Sandwich Islands
+        - South Korea
+        - South Sudan
+        - Spain
+        - Sri Lanka
+        - Sudan
+        - Suriname
+        - Svalbard and Jan Mayen
+        - Sweden
+        - Switzerland
+        - Syria
+        - Taiwan
+        - Tajikistan
+        - Tanzania
+        - Thailand
+        - Timor-Leste
+        - Togo
+        - Tokelau
+        - Tonga
+        - Trinidad and Tobago
+        - Tunisia
+        - Türkiye
+        - Turkmenistan
+        - Turks and Caicos Islands
+        - Tuvalu
+        - Uganda
+        - Ukraine
+        - United Arab Emirates
+        - United Kingdom
+        - United States Minor Outlying Islands
+        - United States of America
+        - Uruguay
+        - Uzbekistan
+        - Vanuatu
+        - Venezuela
+        - Vietnam
+        - Virgin Islands (British)
+        - Virgin Islands (U.S.)
+        - Wallis and Futuna
+        - Western Sahara
+        - Yemen
+        - Zambia
+        - Zimbabwe
+>>>>>>> 27bdec7 (Adding base stuff for product add with discount)
     CyberSourceCheckout:
       type: object
-      description: Really basic serializer for the payload that we need to send to
+      description:
+        Really basic serializer for the payload that we need to send to
         CyberSource.
       properties:
         payload:
@@ -1475,9 +1742,9 @@ components:
         method:
           type: string
       required:
-      - method
-      - payload
-      - url
+        - method
+        - payload
+        - url
     Discount:
       type: object
       description: Serializer for discounts.
@@ -1495,8 +1762,8 @@ components:
         payment_type:
           nullable: true
           oneOf:
-          - $ref: '#/components/schemas/PaymentTypeEnum'
-          - $ref: '#/components/schemas/NullEnum'
+            - $ref: "#/components/schemas/PaymentTypeEnum"
+            - $ref: "#/components/schemas/NullEnum"
         max_redemptions:
           type: integer
           maximum: 2147483647
@@ -1506,46 +1773,48 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: If set, this discount code will not be redeemable before this
+          description:
+            If set, this discount code will not be redeemable before this
             date.
         expiration_date:
           type: string
           format: date-time
           nullable: true
-          description: If set, this discount code will not be redeemable after this
+          description:
+            If set, this discount code will not be redeemable after this
             date.
         integrated_system:
-          $ref: '#/components/schemas/IntegratedSystem'
+          $ref: "#/components/schemas/IntegratedSystem"
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
         assigned_users:
           type: array
           items:
-            $ref: '#/components/schemas/User'
+            $ref: "#/components/schemas/User"
         company:
-          $ref: '#/components/schemas/Company'
+          $ref: "#/components/schemas/Company"
       required:
-      - amount
-      - assigned_users
-      - company
-      - discount_code
-      - id
-      - integrated_system
-      - product
+        - amount
+        - assigned_users
+        - company
+        - discount_code
+        - id
+        - integrated_system
+        - product
     DiscountTypeEnum:
       enum:
-      - percent-off
-      - dollars-off
-      - fixed-price
+        - percent-off
+        - dollars-off
+        - fixed-price
       type: string
       description: |-
         * `percent-off` - percent-off
         * `dollars-off` - dollars-off
         * `fixed-price` - fixed-price
       x-enum-descriptions:
-      - percent-off
-      - dollars-off
-      - fixed-price
+        - percent-off
+        - dollars-off
+        - fixed-price
     IntegratedSystem:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1563,8 +1832,8 @@ components:
         description:
           type: string
       required:
-      - id
-      - name
+        - id
+        - name
     IntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1580,7 +1849,7 @@ components:
         description:
           type: string
       required:
-      - name
+        - name
     Line:
       type: object
       description: Serializes a line item for an order.
@@ -1605,17 +1874,17 @@ components:
           format: decimal
           pattern: ^-?\d{0,7}(?:\.\d{0,2})?$
         product:
-          $ref: '#/components/schemas/Product'
+          $ref: "#/components/schemas/Product"
       required:
-      - id
-      - item_description
-      - product
-      - quantity
-      - total_price
-      - unit_price
+        - id
+        - item_description
+        - product
+        - quantity
+        - total_price
+        - unit_price
     NullEnum:
       enum:
-      - null
+        - null
     OrderHistory:
       type: object
       description: Serializer for order history.
@@ -1624,7 +1893,7 @@ components:
           type: integer
           readOnly: true
         state:
-          $ref: '#/components/schemas/StateEnum'
+          $ref: "#/components/schemas/StateEnum"
         reference_number:
           type: string
           maxLength: 255
@@ -1637,7 +1906,7 @@ components:
         lines:
           type: array
           items:
-            $ref: '#/components/schemas/Line'
+            $ref: "#/components/schemas/Line"
         created_on:
           type: string
           format: date-time
@@ -1647,17 +1916,17 @@ components:
           format: date-time
           readOnly: true
       required:
-      - created_on
-      - id
-      - lines
-      - purchaser
-      - total_price_paid
-      - updated_on
+        - created_on
+        - id
+        - lines
+        - purchaser
+        - total_price_paid
+        - updated_on
     PaginatedBasketWithProductList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1675,12 +1944,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/BasketWithProduct'
+            $ref: "#/components/schemas/BasketWithProduct"
     PaginatedIntegratedSystemList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1698,12 +1967,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/IntegratedSystem'
+            $ref: "#/components/schemas/IntegratedSystem"
     PaginatedOrderHistoryList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1721,12 +1990,12 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/OrderHistory'
+            $ref: "#/components/schemas/OrderHistory"
     PaginatedProductList:
       type: object
       required:
-      - count
-      - results
+        - count
+        - results
       properties:
         count:
           type: integer
@@ -1744,7 +2013,7 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Product'
+            $ref: "#/components/schemas/Product"
     PatchedIntegratedSystemRequest:
       type: object
       description: Serializer for IntegratedSystem model.
@@ -1790,18 +2059,19 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
     PaymentTypeEnum:
       enum:
-      - marketing
-      - sales
-      - financial-assistance
-      - customer-support
-      - staff
-      - legacy
-      - credit_card
-      - purchase_order
+        - marketing
+        - sales
+        - financial-assistance
+        - customer-support
+        - staff
+        - legacy
+        - credit_card
+        - purchase_order
       type: string
       description: |-
         * `marketing` - marketing
@@ -1813,14 +2083,14 @@ components:
         * `credit_card` - credit_card
         * `purchase_order` - purchase_order
       x-enum-descriptions:
-      - marketing
-      - sales
-      - financial-assistance
-      - customer-support
-      - staff
-      - legacy
-      - credit_card
-      - purchase_order
+        - marketing
+        - sales
+        - financial-assistance
+        - customer-support
+        - staff
+        - legacy
+        - credit_card
+        - purchase_order
     Product:
       type: object
       description: Serializer for Product model.
@@ -1855,16 +2125,17 @@ components:
           readOnly: true
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
       required:
-      - deleted_by_cascade
-      - description
-      - id
-      - name
-      - price
-      - sku
-      - system
+        - deleted_by_cascade
+        - description
+        - id
+        - name
+        - price
+        - sku
+        - system
     ProductRequest:
       type: object
       description: Serializer for Product model.
@@ -1896,14 +2167,15 @@ components:
           description: Price (decimal to two places)
         image_metadata:
           nullable: true
-          description: Image metadata including URL, alt text, and description (in
+          description:
+            Image metadata including URL, alt text, and description (in
             JSON).
       required:
-      - description
-      - name
-      - price
-      - sku
-      - system
+        - description
+        - name
+        - price
+        - sku
+        - system
     SimpleDiscount:
       type: object
       description: Simpler serializer for discounts.
@@ -1919,7 +2191,7 @@ components:
           format: decimal
           pattern: ^-?\d{0,18}(?:\.\d{0,2})?$
         discount_type:
-          $ref: '#/components/schemas/DiscountTypeEnum'
+          $ref: "#/components/schemas/DiscountTypeEnum"
         formatted_discount_amount:
           type: string
           description: |-
@@ -1928,20 +2200,20 @@ components:
             This quantizes percent discounts to whole numbers. This is probably fine.
           readOnly: true
       required:
-      - amount
-      - discount_code
-      - discount_type
-      - formatted_discount_amount
-      - id
+        - amount
+        - discount_code
+        - discount_type
+        - formatted_discount_amount
+        - id
     StateEnum:
       enum:
-      - pending
-      - fulfilled
-      - canceled
-      - refunded
-      - declined
-      - errored
-      - review
+        - pending
+        - fulfilled
+        - canceled
+        - refunded
+        - declined
+        - errored
+        - review
       type: string
       description: |-
         * `pending` - Pending
@@ -1952,13 +2224,13 @@ components:
         * `errored` - Errored
         * `review` - Review
       x-enum-descriptions:
-      - Pending
-      - Fulfilled
-      - Canceled
-      - Refunded
-      - Declined
-      - Errored
-      - Review
+        - Pending
+        - Fulfilled
+        - Canceled
+        - Refunded
+        - Declined
+        - Errored
+        - Review
     TaxRate:
       type: object
       description: TaxRate model serializer
@@ -1967,7 +2239,7 @@ components:
           type: integer
           readOnly: true
         country_code:
-          $ref: '#/components/schemas/CountryCodeEnum'
+          $ref: "#/components/schemas/CountryCodeEnum"
         tax_rate:
           type: string
           format: decimal
@@ -1976,8 +2248,8 @@ components:
           type: string
           maxLength: 100
       required:
-      - country_code
-      - id
+        - country_code
+        - id
     User:
       type: object
       description: Serializer for User model.
@@ -1987,7 +2259,8 @@ components:
           readOnly: true
         username:
           type: string
-          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+          description:
+            Required. 150 characters or fewer. Letters, digits and @/./+/-/_
             only.
           pattern: ^[\w.@+-]+$
           maxLength: 150
@@ -2003,5 +2276,5 @@ components:
           type: string
           maxLength: 150
       required:
-      - id
-      - username
+        - id
+        - username

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -202,6 +202,58 @@ def _create_basket_from_product(
         "adding the selected product."
     ),
     methods=["POST"],
+    request=None,
+    responses=BasketWithProductSerializer,
+    parameters=[
+        OpenApiParameter(
+            "system_slug", OpenApiTypes.STR, OpenApiParameter.PATH, required=True
+        ),
+        OpenApiParameter("sku", OpenApiTypes.STR, OpenApiParameter.PATH, required=True),
+    ],
+)
+@api_view(["POST"])
+@permission_classes((IsAuthenticated,))
+def create_basket_from_product(request, system_slug: str, sku: str):
+    """Run _create_basket_from_product."""
+
+    return _create_basket_from_product(request, system_slug, sku)
+
+
+@extend_schema(
+    operation_id="create_basket_from_product_with_discount",
+    description=(
+        "Creates or updates a basket for the current user, "
+        "adding the selected product and discount."
+    ),
+    methods=["POST"],
+    request=None,
+    responses=BasketWithProductSerializer,
+    parameters=[
+        OpenApiParameter(
+            "system_slug", OpenApiTypes.STR, OpenApiParameter.PATH, required=True
+        ),
+        OpenApiParameter("sku", OpenApiTypes.STR, OpenApiParameter.PATH, required=True),
+        OpenApiParameter(
+            "discount_code", OpenApiTypes.STR, OpenApiParameter.PATH, required=True
+        ),
+    ],
+)
+@api_view(["POST"])
+@permission_classes((IsAuthenticated,))
+def create_basket_from_product_with_discount(
+    request, system_slug: str, sku: str, discount_code: Optional[str] = None
+):
+    """Run _create_basket_from_product with the discount code."""
+
+    return _create_basket_from_product(request, system_slug, sku, discount_code)
+
+
+@extend_schema(
+    description=(
+        "Creates or updates a basket for the current user, "
+        "adding the selected product."
+    ),
+    methods=["POST"],
     responses=BasketWithProductSerializer,
     request=CreateBasketWithProductsSerializer,
 )

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -135,7 +135,9 @@ def get_user_basket_for_system(request, system_slug: str):
 )
 @api_view(["POST"])
 @permission_classes((IsAuthenticated,))
-def create_basket_from_product(request, system_slug: str, sku: str):
+def create_basket_from_product(
+    request, system_slug: str, sku: str, discount_code: str = None
+):
     """
     Create a new basket item from a product for the currently logged in user. Reuse
     the existing basket object if it exists.
@@ -181,6 +183,14 @@ def create_basket_from_product(request, system_slug: str, sku: str):
     auto_apply_discount_discounts = api.get_auto_apply_discounts_for_basket(basket.id)
     for discount in auto_apply_discount_discounts:
         basket.apply_discount_to_basket(discount)
+
+    if discount_code:
+        try:
+            discount = Discount.objects.get(discount_code=discount_code)
+            basket.apply_discount_to_basket(discount)
+        except Discount.DoesNotExist:
+            pass
+
     basket.refresh_from_db()
 
     if checkout:

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -1,6 +1,7 @@
 """Views for the REST API for payments."""
 
 import logging
+from typing import Optional
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
@@ -136,7 +137,7 @@ def get_user_basket_for_system(request, system_slug: str):
 @api_view(["POST"])
 @permission_classes((IsAuthenticated,))
 def create_basket_from_product(
-    request, system_slug: str, sku: str, discount_code: str = None
+    request, system_slug: str, sku: str, discount_code: Optional[str] = None
 ):
     """
     Create a new basket item from a product for the currently logged in user. Reuse

--- a/payments/views/v0/__init__.py
+++ b/payments/views/v0/__init__.py
@@ -125,18 +125,7 @@ def get_user_basket_for_system(request, system_slug: str):
     )
 
 
-@extend_schema(
-    description=(
-        "Creates or updates a basket for the current user, "
-        "adding the selected product."
-    ),
-    methods=["POST"],
-    request=None,
-    responses=BasketWithProductSerializer,
-)
-@api_view(["POST"])
-@permission_classes((IsAuthenticated,))
-def create_basket_from_product(
+def _create_basket_from_product(
     request, system_slug: str, sku: str, discount_code: Optional[str] = None
 ):
     """
@@ -147,10 +136,14 @@ def create_basket_from_product(
     basket, then immediately flip the user to the checkout interstitial (which
     then redirects to the payment gateway).
 
+    If the discount code is provided, then it will be applied to the basket. If
+    the discount isn't found or doesn't apply, then it will be ignored.
+
     Args:
+        request (Request): The request object.
         system_slug (str): system slug
         sku (str): product slug
-
+        discount_code (str): discount code
     POST Args:
         quantity (int): quantity of the product to add to the basket (defaults to 1)
         checkout (bool): redirect to checkout interstitial (defaults to False)

--- a/payments/views/v0/urls.py
+++ b/payments/views/v0/urls.py
@@ -12,6 +12,7 @@ from payments.views.v0 import (
     clear_basket,
     create_basket_from_product,
     create_basket_with_products,
+    create_basket_from_product_with_discount,
     get_user_basket_for_system,
     start_checkout,
 )

--- a/payments/views/v0/urls.py
+++ b/payments/views/v0/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
         name="get_user_basket_for_system",
     ),
     path(
-        "baskets/create_from_product/<str:system_slug>/<str:sku>/<str:discount_code>/",
+        "baskets/create_from_product/<str:system_slug>/<str:sku>/",
         create_basket_from_product,
         name="create_from_product",
     ),

--- a/payments/views/v0/urls.py
+++ b/payments/views/v0/urls.py
@@ -30,7 +30,7 @@ urlpatterns = [
         name="get_user_basket_for_system",
     ),
     path(
-        "baskets/create_from_product/<str:system_slug>/<str:sku>/",
+        "baskets/create_from_product/<str:system_slug>/<str:sku>/<str:discount_code>/",
         create_basket_from_product,
         name="create_from_product",
     ),

--- a/payments/views/v0/urls.py
+++ b/payments/views/v0/urls.py
@@ -11,8 +11,8 @@ from payments.views.v0 import (
     add_discount_to_basket,
     clear_basket,
     create_basket_from_product,
-    create_basket_with_products,
     create_basket_from_product_with_discount,
+    create_basket_with_products,
     get_user_basket_for_system,
     start_checkout,
 )
@@ -34,6 +34,11 @@ urlpatterns = [
         "baskets/create_from_product/<str:system_slug>/<str:sku>/",
         create_basket_from_product,
         name="create_from_product",
+    ),
+    path(
+        "baskets/create_from_product/<str:system_slug>/<str:sku>/<str:discount_code>/",
+        create_basket_from_product_with_discount,
+        name="create_from_product_with_discount",
     ),
     path(
         "baskets/create_with_products/",

--- a/payments/views/v0/v0_test.py
+++ b/payments/views/v0/v0_test.py
@@ -1,6 +1,7 @@
 """View tests for the v0 API."""
 
 import pytest
+from django.urls import reverse
 
 from payments.factories import BasketFactory, DiscountFactory, ProductFactory
 from payments.models import Basket
@@ -29,7 +30,7 @@ def test_create_basket_with_products(
         BasketFactory(user=user, integrated_system=system) if existing_basket else None
     )
 
-    url = "/api/v0/payments/baskets/create_with_products/"
+    url = reverse("v0:create_with_products")
     payload = {
         "system_slug": system.slug,
         "skus": [{"sku": product.sku, "quantity": 1} for product in products],
@@ -58,3 +59,76 @@ def test_create_basket_with_products(
 
     if add_discount:
         assert discount in Basket.objects.get(id=basket_id).discounts.all()
+
+
+@pytest.mark.parametrize(
+    ("existing_basket", "add_discount", "bad_product", "bad_discount"),
+    [
+        (True, False, False, False),
+        (False, True, False, False),
+        (False, False, True, False),
+        (False, True, False, True),
+    ],
+)
+def test_create_basket_with_product(
+    mocker, user, user_client, existing_basket, add_discount, bad_product, bad_discount
+):
+    """Test creating a basket with a single product, and/or a discount."""
+
+    mocker.patch("payments.api.send_pre_sale_webhook")
+    system = ActiveIntegratedSystemFactory()
+
+    if bad_product:
+        product = ProductFactory.create()
+    else:
+        product = ProductFactory.create(system=system)
+
+    basket = (
+        BasketFactory(user=user, integrated_system=system) if existing_basket else None
+    )
+
+    url = reverse(
+        "v0:create_from_product",
+        kwargs={"system_slug": system.slug, "sku": product.sku},
+    )
+
+    if add_discount:
+        if bad_discount:
+            discount = DiscountFactory(
+                discount_type="fixed-price",
+                amount=100,
+                integrated_system=ActiveIntegratedSystemFactory(),
+            )
+        else:
+            discount = DiscountFactory(discount_type="fixed-price", amount=100)
+
+        url = reverse(
+            "v0:create_from_product_with_discount",
+            kwargs={
+                "system_slug": system.slug,
+                "sku": product.sku,
+                "discount_code": discount.discount_code,
+            },
+        )
+
+    response = user_client.post(url)
+
+    if bad_product:
+        assert response.status_code == 404
+        return
+
+    # This returns a 201 if we created the _basket line item_.
+    assert response.status_code >= 200
+    assert response.status_code < 300
+
+    basket_id = response.data["id"]
+    assert Basket.objects.get(id=basket_id).basket_items.count() == 1
+
+    if existing_basket:
+        assert basket_id == basket.id
+
+    if add_discount:
+        if bad_discount:
+            assert discount not in Basket.objects.get(id=basket_id).discounts.all()
+        else:
+            assert discount in Basket.objects.get(id=basket_id).discounts.all()


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#6326

### Description (What does it do?)

Updates the `create_basket_from_product` API to accept a discount code too, so one-off product ads can also be specified with a discount.

### How can this be tested?

You'll need to test this through the Swagger UI (or similar) since there's no UI for this at the moment.

The API endpoint is `/api/v0/payments/basket/create_with_product/<system>/<sku>/<discount>/` (i.e., the same one as was there, just with the discount code appended to it). This should create or update the basket for the logged in user with the specified product, and should add the discount to the basket as well. If the discount is not found, this will skip it.
