### PR TITLE
Adding base stuff to handle redirects back into the IS

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -55,8 +55,7 @@ def establish_session(request):
             try:
                 system = IntegratedSystem.objects.get(slug=request.GET["system"])
                 next_url = request.GET["next"]
-                # TODO: waiting on a PR to merge to add in homepage_url
-                next_url = urljoin(system.webhook_url, next_url)
+                next_url = urljoin(system.homepage_url, next_url)
             except IntegratedSystem.DoesNotExist:
                 return redirect(settings.MITOL_UE_PAYMENT_BASKET_CHOOSER)
         else:

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -1,0 +1,82 @@
+"""Tests for the users API views."""
+
+import faker
+import pytest
+from django.conf import settings
+
+from system_meta.factories import ActiveIntegratedSystemFactory
+
+pytestmark = [pytest.mark.django_db]
+FAKE = faker.Faker()
+
+
+def test_current_user(user, client, user_client):
+    """Test the "me" endpoint."""
+
+    me_api = "/api/v0/users/me/"
+
+    resp = client.get(me_api)
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "id": None,
+        "username": "",
+    }
+
+    resp = user_client.get(me_api)
+
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert resp_json["id"] == user.id
+
+
+def test_establish_session_logged_out(client):
+    """
+    Test that establish session returns a 403 when the user is logged out.
+
+    This is counterintuitive - in reality, you get redirected into Keycloak.
+    But that happens upstream, not in the Django app, so _we_ should return a 403.
+    """
+    integrated_system = ActiveIntegratedSystemFactory.create()
+
+    api_kwargs = {
+        "next": integrated_system.slug,
+    }
+
+    establish_session_api = "/establish_session/"
+
+    resp = client.get(establish_session_api, query_params=api_kwargs)
+
+    assert resp.status_code == 403
+
+
+@pytest.mark.parametrize("send_back_to_system", [True, False])
+def test_establish_session_logged_in(user_client, send_back_to_system):
+    """
+    Test that establish session redirects appropriately when the user is logged in.
+
+    If the user is logged in, they should go to either the basket page or back
+    to the integrated system.
+    """
+    integrated_system = ActiveIntegratedSystemFactory.create()
+
+    if send_back_to_system:
+        api_kwargs = {
+            "system": integrated_system.slug,
+            "next": FAKE.uri_path(),
+        }
+    else:
+        api_kwargs = {
+            "next": integrated_system.slug,
+        }
+
+    establish_session_api = "/establish_session/"
+
+    resp = user_client.get(establish_session_api, query_params=api_kwargs)
+
+    assert resp.status_code == 302
+
+    if send_back_to_system:
+        assert integrated_system.homepage_url in resp.headers.get("Location")
+    else:
+        assert settings.MITOL_UE_PAYMENT_BASKET_CHOOSER in resp.headers.get("Location")


### PR DESCRIPTION
_Draft because this requires a homepage URL field in the Integrated system model that is [in a different PR](https://github.com/mitodl/unified-ecommerce/pull/198)._

### What are the relevant tickets?

mitodl/hq#6520
https://github.com/mitodl/mitxonline/pull/2515

### Description (What does it do?)

`establish_session` creates a session for the user, and then expects to send the user to the UE frontend afterwards. We need it to also be able to redirect back into the integrated system, so this adds that functionality.

### How can this be tested?

This is (essentially) written for MITx Online for now, so you should have a copy of that set up. It doesn't need to have any data in it other than a user so you can log in. You will need to have it set up to track the work [in this PR.](https://github.com/mitodl/mitxonline/pull/2515) 

Follow the instructions in the MITx Online PR to test. You can also test directly: the URL format is `<root url>/establish_session?next=<a URL>&system=<system slug>` and you will need to ensure the homepage URL is set up to redirect to something known. Upon loading, you should have to log into Keycloak, and then you should be sent to the URL you specified.

Going to `establish_session` in the normal manner - i.e., via the UE frontend - should work as it has before.
