### PR TITLE
Make some minor changes to add the Git hash into the built container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ generated-codes.csv
 
 # Manually-built ol-django packages
 mitol_django_*
+
+# Release management hash
+hash.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN chown -R mitodl:mitodl /src
 
 # Store current Git hash, for release management
 USER mitodl
-RUN sh scripts/get-hash.sh
+RUN /bin/sh scripts/get-hash.sh
 
 EXPOSE 8073
 ENV PORT=8073

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.13.2
-LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
+LABEL maintainer="ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
 WORKDIR /tmp
@@ -52,9 +52,12 @@ USER root
 COPY . /src
 WORKDIR /src
 RUN mkdir /src/staticfiles
+RUN chown -R mitodl:mitodl /src
 
+# Store current Git hash, for release management
 USER mitodl
+RUN sh scripts/get-hash.sh
 
 EXPOSE 8073
-ENV PORT 8073
-CMD uwsgi uwsgi.ini
+ENV PORT=8073
+CMD ["uwsgi", "uwsgi.ini"]

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -15,6 +15,11 @@ server {
         try_files /static/images/favicon.ico /favicon.ico;
     }
 
+    location = /static/hash.txt {
+        add_header Access-Control-Allow-Origin *;
+        try_files /hash.txt =404;
+    }
+
     location ~* /static/(.*$) {
         expires max;
         add_header Access-Control-Allow-Origin *;

--- a/scripts/get-hash.sh
+++ b/scripts/get-hash.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Simple wrapper to get the current Git hash and store it in staticfiles/hash.txt.
+
+git rev-parse origin >hash.txt

--- a/scripts/get-hash.sh
+++ b/scripts/get-hash.sh
@@ -2,4 +2,5 @@
 
 # Simple wrapper to get the current Git hash and store it in staticfiles/hash.txt.
 
-git rev-parse origin >hash.txt
+set -e
+git rev-parse HEAD >hash.txt


### PR DESCRIPTION

### What are the relevant tickets?

Partially closes mitodl/hq#6236

### Description (What does it do?)

- Adds a script to grab out the current commit's hash
- Update the `.gitignore` to ignore the generated hash
- Update Dockerfile to generate hash on build and store it in a known place
- Update nginx config to allow it to serve up the hash

### How can this be tested?

- Build the images using `docker compose build`, then run `bash` the `web` container outside of the Compose environment. (So, for example, `docker run --rm -ti unified-ecommerce-web bash`.) Then, check that `/src/hash.txt` exists and contains the hash for the current commit. (That should be `db4e8a889cdf657b0c572dd650637dd192743c61` for this branch.) 
- Start the app up normally, then navigate to http://ue.odl.local:9080/static/hash.txt and make sure it loads. You should get that same commit hash back.

### Additional Context

For apps that get deployed to Heroku, the release action in GitHub would take care of this step. The Kubernetes deployments use the Dockerfile in the app so it made some sense to me to build it in there. 

The `hash.txt` isn't put into `staticfiles` because Django will clear that folder when the system comes up (`collectstatic` gets run and it deletes everything from that folder).

The nginx config changes will also need to be replicated in ol-infrastructure ([here](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/unified_ecommerce/files/web.conf) most likely?). 